### PR TITLE
Implement clean SEO-friendly URLs for articles

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,5 @@
+# Redirect rules for clean article URLs
+# This tells the server to serve /en/articles/index.html for all /en/articles/* URLs
+# while keeping the clean URL in the browser
+
+/en/articles/*  /en/articles/index.html  200

--- a/en/articles/index.html
+++ b/en/articles/index.html
@@ -291,17 +291,22 @@
         const API_BASE_URL = 'https://marketing-production-a3ee.up.railway.app/api';
         const SITE_BASE_URL = 'https://wordsthatsells.website';
 
-        // Extract slug from URL query parameter or path
+        // Extract slug from URL path (clean URL format)
         function getSlugFromURL() {
-            // Try query parameter first: ?slug=article-slug
-            const urlParams = new URLSearchParams(window.location.search);
-            const querySlug = urlParams.get('slug');
-            if (querySlug) return querySlug;
-
-            // Fallback: Try to get from path: /en/articles/article-slug
+            // Get path: /en/articles/article-slug
             const path = window.location.pathname;
             const parts = path.split('/').filter(p => p && p !== 'index.html');
-            return parts[parts.length - 1] || null;
+
+            // Last part should be the slug
+            // Path will be: ['en', 'articles', 'article-slug']
+            const slug = parts[parts.length - 1];
+
+            // If slug is 'articles', it means we're at /en/articles/ with no slug
+            if (slug === 'articles') {
+                return null;
+            }
+
+            return slug || null;
         }
 
         // Calculate reading time

--- a/en/resources/articles/index.html
+++ b/en/resources/articles/index.html
@@ -940,7 +940,7 @@
                 featured: article.featured || false,
                 sidebar_content: article.sidebar_content || article.content || '<p>Preview not available.</p>',
                 full_article_content: article.full_article_content || article.content || '<p>Content not available.</p>',
-                read_more_link: `${SITE_BASE_URL}/en/articles/?slug=${article.slug}`
+                read_more_link: `${SITE_BASE_URL}/en/articles/${article.slug}`
             };
         }
 
@@ -1214,7 +1214,7 @@
 
             // Update share buttons in sidebar content to use dynamic slug
             let contentWithDynamicShares = postData.sidebar_content;
-            const articleUrl = `${SITE_BASE_URL}/en/articles/?slug=${postData.slug}`;
+            const articleUrl = `${SITE_BASE_URL}/en/articles/${postData.slug}`;
 
             // Replace share button URLs and onclick handlers
             contentWithDynamicShares = contentWithDynamicShares.replace(

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+# Netlify configuration for clean URLs
+# This enables clean article URLs like /en/articles/article-slug
+
+[[redirects]]
+  from = "/en/articles/*"
+  to = "/en/articles/index.html"
+  status = 200
+  force = false

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/en/articles/:slug",
+      "destination": "/en/articles/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
- Change URL format from ?slug= to clean path-based URLs
- Update article page to parse slug from pathname
- Update sidebar Read More button to use clean URLs
- Add hosting platform configurations:
  - _redirects for Netlify/Railway
  - netlify.toml for Netlify
  - vercel.json for Vercel
- URL now: /en/articles/article-slug (instead of ?slug=article-slug)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented clean article URLs using path-based routing instead of query parameters. Articles now use the format `/en/articles/slug` for improved readability and shareability.

* **Chores**
  * Added deployment configuration for URL redirect handling across hosting platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->