### PR TITLE
Include all article images in JSON-LD Schema Markup

### DIFF
--- a/en/articles/index.html
+++ b/en/articles/index.html
@@ -459,12 +459,21 @@
 
             // Otherwise generate from article data
             const ogImage = sm.og_image || article.featured_image_url || '';
+            // Collect all article images (featured/OG + article_images)
+            const images = [];
+            if (ogImage) images.push(ogImage);
+            if (Array.isArray(article.article_images)) {
+                article.article_images.forEach(img => {
+                    const url = img.cdn_url || img.url || '';
+                    if (url && !images.includes(url)) images.push(url);
+                });
+            }
             return {
                 "@context": "https://schema.org",
                 "@type": "Article",
                 "headline": article.title,
                 "description": sm.og_description || article.description || '',
-                "image": ogImage ? [ogImage] : [],
+                "image": images,
                 "datePublished": article.published_at || article.created_at,
                 "dateModified": article.updated_at || article.created_at,
                 "author": {

--- a/generate-seo-articles.js
+++ b/generate-seo-articles.js
@@ -122,12 +122,22 @@ function generateSchemaMarkup(article) {
     return social.schemaMarkup;
   }
 
+  // Collect all article images (featured/OG + article_images)
+  const images = [];
+  if (social.ogImage) images.push(social.ogImage);
+  if (Array.isArray(article.article_images)) {
+    article.article_images.forEach(img => {
+      const url = img.cdn_url || img.url || '';
+      if (url && !images.includes(url)) images.push(url);
+    });
+  }
+
   return {
     "@context": "https://schema.org",
     "@type": "Article",
     "headline": article.title,
     "description": social.ogDescription,
-    "image": social.ogImage ? [social.ogImage] : [],
+    "image": images,
     "datePublished": formatSchemaDate(article.published_at || article.created_at),
     "dateModified": formatSchemaDate(article.updated_at || article.created_at),
     "author": {

--- a/wts-admin/src/routes/public-api.js
+++ b/wts-admin/src/routes/public-api.js
@@ -49,7 +49,7 @@ router.get('/articles', async (req, res) => {
              seo_title, seo_description, featured, published_url, published_at, created_at, updated_at,
              og_title, og_description, og_image, og_type,
              twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator,
-             canonical_url, robots_meta, schema_markup
+             canonical_url, robots_meta, schema_markup, article_images
       FROM articles
       WHERE status = 'published'
     `;
@@ -79,6 +79,7 @@ router.get('/articles', async (req, res) => {
       sidebar_content: article.excerpt || article.content?.substring(0, 500) || '',
       full_article_content: article.content,
       published_url: article.published_url || '',
+      article_images: article.article_images || [],
       created_at: article.created_at,
       updated_at: article.updated_at,
       published_at: article.published_at,
@@ -133,6 +134,7 @@ router.get('/articles/:slug', async (req, res) => {
       published_url: article.published_url || '',
       full_article_content: article.content,
       time_to_read: article.time_to_read || null,
+      article_images: article.article_images || [],
       created_at: article.created_at,
       updated_at: article.updated_at,
       published_at: article.published_at,

--- a/wts-admin/src/views/content/articles/form.ejs
+++ b/wts-admin/src/views/content/articles/form.ejs
@@ -1463,12 +1463,30 @@ function generateSchemaMarkup() {
   var timeToRead = document.getElementById('time_to_read').value || '';
   var seoKeywords = document.getElementById('seo_keywords').value || '';
 
+  // Collect all article images
+  var images = [];
+  if (image) images.push(image);
+  try {
+    var articleImagesJson = document.getElementById('article_images').value;
+    if (articleImagesJson) {
+      var articleImgs = JSON.parse(articleImagesJson);
+      if (Array.isArray(articleImgs)) {
+        articleImgs.forEach(function(img) {
+          var url = img.cdn_url || img.url || '';
+          if (url && images.indexOf(url) === -1) {
+            images.push(url);
+          }
+        });
+      }
+    }
+  } catch(e) { /* ignore parse errors */ }
+
   var schema = {
     "@context": "https://schema.org",
     "@type": "Article",
     "headline": title,
     "description": seoDesc || excerpt,
-    "image": image ? [image] : [],
+    "image": images,
     "author": {
       "@type": "Organization",
       "name": "Words That Sells",


### PR DESCRIPTION
Add article_images array to public API response and update all schema generators (CMS form, dynamic frontend, static generator) to include every image associated with an article in the Schema.org "image" field, not just the featured/OG image.

https://claude.ai/code/session_017sWNKFvvxPsLNnpBZzXpjJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Articles now support multiple images in schema markup, enabling richer search engine results and improved visibility across search platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->