### PR TITLE
Add article Content Labels sidebar card feature

### DIFF
--- a/en/articles/index.html
+++ b/en/articles/index.html
@@ -81,9 +81,16 @@
 
         .container {
             width: 90%;
-            max-width: 900px;
+            max-width: 1200px;
             margin: 0 auto;
             padding: var(--spacing-3xl) 0;
+        }
+
+        .article-layout {
+            display: grid;
+            grid-template-columns: 1fr 340px;
+            gap: var(--spacing-2xl);
+            align-items: start;
         }
 
         .article-header {
@@ -419,6 +426,219 @@
             color: var(--color-white);
         }
 
+        /* --- Article Sidebar Card --- */
+        .article-sidebar {
+            position: sticky;
+            top: 24px;
+        }
+
+        .sidebar-card {
+            background: var(--color-white);
+            border: 1px solid var(--color-border);
+            border-radius: var(--border-radius-lg);
+            box-shadow: var(--shadow-md);
+            overflow: hidden;
+        }
+
+        .sidebar-card-image {
+            width: 100%;
+            height: 180px;
+            object-fit: cover;
+        }
+
+        .sidebar-card-body {
+            padding: 20px;
+        }
+
+        .sidebar-card-category {
+            display: inline-block;
+            background: var(--color-primary-base);
+            color: var(--color-white);
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            padding: 3px 10px;
+            border-radius: 999px;
+            margin-bottom: 10px;
+        }
+
+        .sidebar-card-title {
+            font-family: var(--font-family-heading);
+            font-size: 1.1rem;
+            font-weight: 700;
+            color: var(--color-slate-900);
+            line-height: 1.3;
+            margin-bottom: 8px;
+        }
+
+        .sidebar-card-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            font-size: 0.75rem;
+            color: var(--color-slate-500);
+            margin-bottom: 12px;
+        }
+
+        .sidebar-card-meta span {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .sidebar-card-meta i {
+            color: var(--color-primary-base);
+            font-size: 0.7rem;
+        }
+
+        .sidebar-card-desc {
+            font-size: 0.85rem;
+            color: var(--color-slate-500);
+            line-height: 1.6;
+            margin-bottom: 16px;
+        }
+
+        .sidebar-section {
+            border-top: 1px solid var(--color-border);
+            padding-top: 14px;
+            margin-top: 14px;
+        }
+
+        .sidebar-section-title {
+            font-family: var(--font-family-heading);
+            font-size: 0.8rem;
+            font-weight: 700;
+            color: var(--color-slate-900);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 8px;
+        }
+
+        .sidebar-section ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+
+        .sidebar-section ul li {
+            font-size: 0.82rem;
+            color: var(--color-slate-800);
+            padding: 3px 0;
+            padding-left: 16px;
+            position: relative;
+            line-height: 1.5;
+        }
+
+        .sidebar-section ul li::before {
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 10px;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: var(--color-primary-base);
+        }
+
+        .sidebar-key-point {
+            margin-bottom: 8px;
+        }
+
+        .sidebar-key-point-title {
+            font-weight: 700;
+            font-size: 0.82rem;
+            color: var(--color-slate-900);
+        }
+
+        .sidebar-key-point-desc {
+            font-size: 0.8rem;
+            color: var(--color-slate-500);
+            line-height: 1.5;
+        }
+
+        .sidebar-sources-badges {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin-bottom: 8px;
+        }
+
+        .sidebar-source-badge {
+            font-size: 0.7rem;
+            font-weight: 600;
+            padding: 3px 8px;
+            border-radius: 999px;
+            background: #f0f4f8;
+            color: var(--color-slate-800);
+            text-decoration: none;
+            transition: background 0.2s;
+        }
+
+        .sidebar-source-badge:hover {
+            background: var(--color-primary-base);
+            color: var(--color-white);
+        }
+
+        .sidebar-read-bar {
+            border-top: 1px solid var(--color-border);
+            padding: 14px 20px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            background: #f8fafc;
+        }
+
+        .sidebar-read-stats {
+            display: flex;
+            gap: 14px;
+            font-size: 0.72rem;
+            color: var(--color-slate-500);
+        }
+
+        .sidebar-read-stats span {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .sidebar-read-stats i {
+            color: var(--color-primary-base);
+            font-size: 0.7rem;
+        }
+
+        .sidebar-cta-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            background: var(--color-accent-magenta);
+            color: var(--color-white);
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 8px 16px;
+            border-radius: 6px;
+            text-decoration: none;
+            transition: background 0.2s;
+            white-space: nowrap;
+        }
+
+        .sidebar-cta-btn:hover {
+            background: #b8236f;
+            color: var(--color-white);
+        }
+
+        @media (max-width: 960px) {
+            .article-layout {
+                grid-template-columns: 1fr;
+            }
+
+            .article-sidebar {
+                position: static;
+                order: -1;
+            }
+        }
+
         @media (max-width: 768px) {
             .container {
                 width: 95%;
@@ -454,11 +674,14 @@
             <i class="fas fa-arrow-left"></i> Back to All Articles
         </a>
 
-        <div id="article-container">
-            <div class="loading-state">
-                <i class="fas fa-spinner"></i>
-                <p>Loading article...</p>
+        <div class="article-layout">
+            <div id="article-container">
+                <div class="loading-state">
+                    <i class="fas fa-spinner"></i>
+                    <p>Loading article...</p>
+                </div>
             </div>
+            <aside class="article-sidebar" id="article-sidebar" style="display:none;"></aside>
         </div>
     </div>
 
@@ -844,6 +1067,9 @@
                     </article>
                 `;
 
+                // Render the sidebar card
+                renderSidebarCard(article);
+
                 // Add event listeners to share buttons (use social_meta for per-platform text)
                 setTimeout(() => {
                     const sm = article.social_meta || {};
@@ -1116,6 +1342,124 @@
         document.addEventListener('keydown', function(e) {
             if (e.key === 'Escape') closeTooltip();
         });
+
+        // ==================== SIDEBAR CARD RENDERING ====================
+        function renderSidebarCard(article) {
+            const sidebar = document.getElementById('article-sidebar');
+            const cl = article.content_labels || {};
+
+            // Check if there's any content_labels data worth showing
+            const hasDescription = cl.description && cl.description.trim();
+            const hasWhoShouldRead = cl.who_should_read && cl.who_should_read.length > 0;
+            const hasKeyPoints = cl.key_points && cl.key_points.length > 0;
+            const hasSources = cl.sources && cl.sources.length > 0;
+
+            if (!hasDescription && !hasWhoShouldRead && !hasKeyPoints && !hasSources) {
+                sidebar.style.display = 'none';
+                return;
+            }
+
+            const readingTime = article.time_to_read || calculateReadingTime(article.full_article_content || article.content || '');
+            const content = article.full_article_content || article.content || '';
+            const tempDiv = document.createElement('div');
+            tempDiv.innerHTML = content;
+            const textContent = (tempDiv.textContent || tempDiv.innerText || '').trim();
+            const wordCount = textContent.split(/\s+/).filter(w => w.length > 0).length;
+            const publishedDate = formatDate(article.published_at || article.created_at);
+            const sourcesCount = (cl.sources || []).length + (article.citations || []).length;
+            const faqsCount = cl.faqs_count || 0;
+            const ctaText = cl.cta_text || 'Read Full Article';
+
+            let html = '<div class="sidebar-card">';
+
+            // Featured image
+            if (article.featured_image_url) {
+                html += '<img src="' + article.featured_image_url + '" alt="' + (article.title || '').replace(/"/g, '&quot;') + '" class="sidebar-card-image" onerror="this.style.display=\'none\'">';
+            }
+
+            html += '<div class="sidebar-card-body">';
+
+            // Category pill
+            if (article.categories && article.categories.length > 0) {
+                html += '<span class="sidebar-card-category">' + article.categories[0] + '</span>';
+            }
+
+            // Title
+            html += '<h3 class="sidebar-card-title">' + (article.title || '') + '</h3>';
+
+            // Meta info
+            html += '<div class="sidebar-card-meta">';
+            html += '<span><i class="fas fa-calendar"></i> ' + publishedDate + '</span>';
+            html += '<span><i class="fas fa-clock"></i> ' + readingTime + ' min read</span>';
+            if (sourcesCount > 0) {
+                html += '<span><i class="fas fa-book"></i> ' + sourcesCount + ' sources</span>';
+            }
+            html += '</div>';
+
+            // Description
+            if (hasDescription) {
+                html += '<p class="sidebar-card-desc">' + cl.description + '</p>';
+            }
+
+            // Who Should Read This
+            if (hasWhoShouldRead) {
+                html += '<div class="sidebar-section">';
+                html += '<h4 class="sidebar-section-title"><i class="fas fa-users" style="color: var(--color-primary-base); margin-right: 4px;"></i> Who Should Read This</h4>';
+                html += '<ul>';
+                cl.who_should_read.forEach(function(item) {
+                    html += '<li>' + item + '</li>';
+                });
+                html += '</ul>';
+                html += '</div>';
+            }
+
+            // Key Points
+            if (hasKeyPoints) {
+                html += '<div class="sidebar-section">';
+                html += '<h4 class="sidebar-section-title"><i class="fas fa-lightbulb" style="color: var(--color-primary-base); margin-right: 4px;"></i> What You\'ll Learn</h4>';
+                cl.key_points.forEach(function(kp) {
+                    html += '<div class="sidebar-key-point">';
+                    if (kp.title) html += '<div class="sidebar-key-point-title">' + kp.title + '</div>';
+                    if (kp.description) html += '<div class="sidebar-key-point-desc">' + kp.description + '</div>';
+                    html += '</div>';
+                });
+                html += '</div>';
+            }
+
+            // Sources Referenced
+            if (hasSources) {
+                html += '<div class="sidebar-section">';
+                html += '<h4 class="sidebar-section-title"><i class="fas fa-book-open" style="color: var(--color-primary-base); margin-right: 4px;"></i> Sources Referenced</h4>';
+                html += '<div class="sidebar-sources-badges">';
+                cl.sources.forEach(function(src) {
+                    if (src.url) {
+                        html += '<a href="' + src.url + '" target="_blank" rel="noopener" class="sidebar-source-badge">' + (src.name || 'Source') + '</a>';
+                    } else {
+                        html += '<span class="sidebar-source-badge">' + (src.name || 'Source') + '</span>';
+                    }
+                });
+                html += '</div>';
+                html += '</div>';
+            }
+
+            html += '</div>'; // end sidebar-card-body
+
+            // Read stats bar
+            html += '<div class="sidebar-read-bar">';
+            html += '<div class="sidebar-read-stats">';
+            html += '<span><i class="fas fa-file-alt"></i> ' + wordCount.toLocaleString() + ' words</span>';
+            if (faqsCount > 0) {
+                html += '<span><i class="fas fa-question-circle"></i> ' + faqsCount + ' FAQs</span>';
+            }
+            html += '</div>';
+            html += '<a href="#article-container" class="sidebar-cta-btn">' + ctaText + ' <i class="fas fa-arrow-right"></i></a>';
+            html += '</div>';
+
+            html += '</div>'; // end sidebar-card
+
+            sidebar.innerHTML = html;
+            sidebar.style.display = '';
+        }
 
         // Load article and initialize features on page load
         document.addEventListener('DOMContentLoaded', async () => {

--- a/wts-admin/database/db.js
+++ b/wts-admin/database/db.js
@@ -225,6 +225,9 @@ const db = {
           IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='articles' AND column_name='citations') THEN
             ALTER TABLE articles ADD COLUMN citations JSONB DEFAULT '[]'::jsonb;
           END IF;
+          IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='articles' AND column_name='content_labels') THEN
+            ALTER TABLE articles ADD COLUMN content_labels JSONB DEFAULT '{}'::jsonb;
+          END IF;
         END $$;
       `);
 

--- a/wts-admin/src/routes/content.js
+++ b/wts-admin/src/routes/content.js
@@ -104,7 +104,7 @@ router.post('/articles', [
   }
 
   try {
-    const { title, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations } = req.body;
+    const { title, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels } = req.body;
     const slug = createSlug(title);
     const tagsArray = tags ? tags.split(',').map(t => t.trim()).filter(t => t) : [];
     const keywordsArray = seo_keywords ? seo_keywords.split(',').map(k => k.trim()).filter(k => k) : [];
@@ -121,11 +121,15 @@ router.post('/articles', [
     if (citations && citations.trim()) {
       try { citationsArray = JSON.parse(citations); } catch(e) { citationsArray = []; }
     }
+    let contentLabelsJson = {};
+    if (content_labels && content_labels.trim()) {
+      try { contentLabelsJson = JSON.parse(content_labels); } catch(e) { contentLabelsJson = {}; }
+    }
 
     await db.query(
-      `INSERT INTO articles (title, slug, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, author_id, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33)`,
-      [title, slug, content, excerpt, category, tagsArray, seo_title, seo_description, keywordsArray, status || 'draft', featured_image, published_url, article_code, isFeatured, req.user.id, publishedAtValue, updatedAtValue, timeToRead, JSON.stringify(articleImagesArray), og_title, og_description, og_image, og_type || 'article', twitter_card || 'summary_large_image', twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta || 'index, follow', schemaMarkupJson ? JSON.stringify(schemaMarkupJson) : null, JSON.stringify(citationsArray)]
+      `INSERT INTO articles (title, slug, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, author_id, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34)`,
+      [title, slug, content, excerpt, category, tagsArray, seo_title, seo_description, keywordsArray, status || 'draft', featured_image, published_url, article_code, isFeatured, req.user.id, publishedAtValue, updatedAtValue, timeToRead, JSON.stringify(articleImagesArray), og_title, og_description, og_image, og_type || 'article', twitter_card || 'summary_large_image', twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta || 'index, follow', schemaMarkupJson ? JSON.stringify(schemaMarkupJson) : null, JSON.stringify(citationsArray), JSON.stringify(contentLabelsJson)]
     );
 
     req.session.successMessage = 'Article created successfully';
@@ -163,7 +167,7 @@ router.get('/articles/:id/edit', async (req, res) => {
 // Update article
 router.post('/articles/:id', async (req, res) => {
   try {
-    const { title, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations } = req.body;
+    const { title, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels } = req.body;
 
     // Validate required fields
     if (!title || !title.trim()) {
@@ -190,6 +194,10 @@ router.post('/articles/:id', async (req, res) => {
     if (citations && citations.trim()) {
       try { citationsArray = JSON.parse(citations); } catch(e) { citationsArray = []; }
     }
+    let contentLabelsJson = {};
+    if (content_labels && content_labels.trim()) {
+      try { contentLabelsJson = JSON.parse(content_labels); } catch(e) { contentLabelsJson = {}; }
+    }
 
     const result = await db.query(
       `UPDATE articles
@@ -205,9 +213,9 @@ router.post('/articles/:id', async (req, res) => {
            twitter_card = $23, twitter_title = $24, twitter_description = $25,
            twitter_image = $26, twitter_site = $27, twitter_creator = $28,
            canonical_url = $29, robots_meta = $30, schema_markup = $31,
-           citations = $32::jsonb
+           citations = $32::jsonb, content_labels = $33::jsonb
        WHERE id = $18 RETURNING id`,
-      [title, content, excerpt, category, tagsArray, seo_title, seo_description, keywordsArray, status, featured_image, published_url, isFeatured, updatedAtValue, publishedAtValue, timeToRead, article_code, JSON.stringify(articleImagesArray), req.params.id, og_title, og_description, og_image, og_type || 'article', twitter_card || 'summary_large_image', twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta || 'index, follow', schemaMarkupJson ? JSON.stringify(schemaMarkupJson) : null, JSON.stringify(citationsArray)]
+      [title, content, excerpt, category, tagsArray, seo_title, seo_description, keywordsArray, status, featured_image, published_url, isFeatured, updatedAtValue, publishedAtValue, timeToRead, article_code, JSON.stringify(articleImagesArray), req.params.id, og_title, og_description, og_image, og_type || 'article', twitter_card || 'summary_large_image', twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta || 'index, follow', schemaMarkupJson ? JSON.stringify(schemaMarkupJson) : null, JSON.stringify(citationsArray), JSON.stringify(contentLabelsJson)]
     );
 
     if (result.rowCount === 0) {

--- a/wts-admin/src/routes/public-api.js
+++ b/wts-admin/src/routes/public-api.js
@@ -50,7 +50,7 @@ router.get('/articles', async (req, res) => {
              og_title, og_description, og_image, og_type,
              twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator,
              canonical_url, robots_meta, schema_markup, article_images, citations,
-             time_to_read, seo_keywords
+             time_to_read, seo_keywords, content_labels
       FROM articles
       WHERE status = 'published'
     `;
@@ -84,6 +84,7 @@ router.get('/articles', async (req, res) => {
       citations: article.citations || [],
       time_to_read: article.time_to_read || null,
       seo_keywords: article.seo_keywords || [],
+      content_labels: article.content_labels || {},
       created_at: article.created_at,
       updated_at: article.updated_at,
       published_at: article.published_at,
@@ -141,6 +142,7 @@ router.get('/articles/:slug', async (req, res) => {
       article_images: article.article_images || [],
       citations: article.citations || [],
       seo_keywords: article.seo_keywords || [],
+      content_labels: article.content_labels || {},
       created_at: article.created_at,
       updated_at: article.updated_at,
       published_at: article.published_at,

--- a/wts-admin/src/views/content/articles/form.ejs
+++ b/wts-admin/src/views/content/articles/form.ejs
@@ -447,6 +447,56 @@
             </div>
           </div>
 
+          <!-- Content Labels / Sidebar Card Section -->
+          <div class="form-section">
+            <h3 class="form-section-title"><i class="fas fa-id-card"></i> Content Labels (Article Sidebar Card)</h3>
+            <p class="form-help" style="margin-bottom: 12px;">Configure the sidebar preview card shown alongside the article. This standardized card helps readers understand the article at a glance.</p>
+            <input type="hidden" id="content_labels" name="content_labels" value="<%= article && article.content_labels ? (typeof article.content_labels === 'string' ? article.content_labels : JSON.stringify(article.content_labels)) : '{}' %>">
+
+            <div class="form-group">
+              <label class="form-label" for="cl_description"><i class="fas fa-align-left"></i> Card Description</label>
+              <textarea id="cl_description" name="cl_description" class="form-input" rows="3" placeholder="A short description that appears on the sidebar card..." oninput="updateContentLabels()"></textarea>
+              <p class="form-help">Shown at the top of the sidebar card below the title.</p>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="cl_who_should_read"><i class="fas fa-users"></i> Who Should Read This</label>
+              <textarea id="cl_who_should_read" name="cl_who_should_read" class="form-input" rows="4" placeholder="Marketing professionals&#10;Business owners&#10;SEO specialists" oninput="updateContentLabels()"></textarea>
+              <p class="form-help">One audience type per line. Displayed as a bullet list.</p>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label"><i class="fas fa-lightbulb"></i> What You'll Learn (Key Points)</label>
+              <p class="form-help" style="margin-bottom: 8px;">Add key points with a bold title and description.</p>
+              <div id="keyPointsList" class="key-points-list"></div>
+              <button type="button" class="btn btn-secondary" onclick="addKeyPoint()" style="margin-top: 8px;">
+                <i class="fas fa-plus"></i> Add Key Point
+              </button>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label"><i class="fas fa-book-open"></i> Sources Referenced</label>
+              <p class="form-help" style="margin-bottom: 8px;">Add source badges and links shown on the sidebar card.</p>
+              <div id="sidebarSourcesList" class="sidebar-sources-list"></div>
+              <button type="button" class="btn btn-secondary" onclick="addSidebarSource()" style="margin-top: 8px;">
+                <i class="fas fa-plus"></i> Add Source
+              </button>
+            </div>
+
+            <div class="form-row">
+              <div class="form-group">
+                <label class="form-label" for="cl_faqs_count"><i class="fas fa-question-circle"></i> FAQs Count</label>
+                <input type="number" id="cl_faqs_count" name="cl_faqs_count" class="form-input" min="0" placeholder="e.g. 5" oninput="updateContentLabels()">
+                <p class="form-help">Number of FAQs in the article</p>
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="cl_cta_text"><i class="fas fa-mouse-pointer"></i> CTA Button Text</label>
+                <input type="text" id="cl_cta_text" name="cl_cta_text" class="form-input" placeholder="Read Full Article" oninput="updateContentLabels()">
+                <p class="form-help">Custom text for the call-to-action button (default: "Read Full Article")</p>
+              </div>
+            </div>
+          </div>
+
           <div class="form-actions">
             <a href="/content/articles" class="btn btn-secondary">Cancel</a>
             <button type="submit" class="btn btn-primary">
@@ -1038,6 +1088,27 @@
   background: rgba(255,255,255,0.2);
   color: #fff;
 }
+
+/* Key points list */
+.key-points-list { margin-top: 8px; }
+.key-point-item {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 6px;
+  align-items: flex-start;
+}
+.key-point-item input { flex: 0.35; }
+.key-point-item textarea { flex: 0.65; min-height: 36px; }
+
+/* Sidebar sources list */
+.sidebar-sources-list { margin-top: 8px; }
+.sidebar-source-item {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 6px;
+  align-items: center;
+}
+.sidebar-source-item input { flex: 1; }
 
 /* Citations list */
 .citation-list { margin-top: 8px; }
@@ -1907,6 +1978,117 @@ function openSocialImageModal() {
     }
   };
   loadImages(1);
+}
+
+// ==================== Content Labels Management ====================
+var contentLabelsData = {};
+var keyPointsData = [];
+var sidebarSourcesData = [];
+
+document.addEventListener('DOMContentLoaded', function() {
+  try {
+    var clVal = document.getElementById('content_labels').value;
+    contentLabelsData = clVal ? JSON.parse(clVal) : {};
+  } catch(e) { contentLabelsData = {}; }
+
+  // Populate form fields from stored data
+  if (contentLabelsData.description) document.getElementById('cl_description').value = contentLabelsData.description;
+  if (contentLabelsData.who_should_read && Array.isArray(contentLabelsData.who_should_read)) {
+    document.getElementById('cl_who_should_read').value = contentLabelsData.who_should_read.join('\n');
+  }
+  if (contentLabelsData.faqs_count) document.getElementById('cl_faqs_count').value = contentLabelsData.faqs_count;
+  if (contentLabelsData.cta_text) document.getElementById('cl_cta_text').value = contentLabelsData.cta_text;
+
+  keyPointsData = contentLabelsData.key_points || [];
+  sidebarSourcesData = contentLabelsData.sources || [];
+  renderKeyPoints();
+  renderSidebarSources();
+});
+
+function updateContentLabels() {
+  var desc = document.getElementById('cl_description').value.trim();
+  var whoLines = document.getElementById('cl_who_should_read').value.split('\n').map(function(l) { return l.trim(); }).filter(function(l) { return l; });
+  var faqsCount = parseInt(document.getElementById('cl_faqs_count').value) || 0;
+  var ctaText = document.getElementById('cl_cta_text').value.trim();
+
+  contentLabelsData.description = desc;
+  contentLabelsData.who_should_read = whoLines;
+  contentLabelsData.key_points = keyPointsData;
+  contentLabelsData.sources = sidebarSourcesData;
+  contentLabelsData.faqs_count = faqsCount;
+  contentLabelsData.cta_text = ctaText;
+
+  document.getElementById('content_labels').value = JSON.stringify(contentLabelsData);
+}
+
+function addKeyPoint() {
+  keyPointsData.push({ title: '', description: '' });
+  updateContentLabels();
+  renderKeyPoints();
+}
+
+function removeKeyPoint(index) {
+  keyPointsData.splice(index, 1);
+  updateContentLabels();
+  renderKeyPoints();
+}
+
+function updateKeyPointField(index, field, value) {
+  keyPointsData[index][field] = value;
+  updateContentLabels();
+}
+
+function renderKeyPoints() {
+  var container = document.getElementById('keyPointsList');
+  container.innerHTML = '';
+  if (keyPointsData.length === 0) {
+    container.innerHTML = '<p style="color: var(--gray-500); font-size: 14px; margin: 4px 0;">No key points added yet</p>';
+    return;
+  }
+  keyPointsData.forEach(function(kp, i) {
+    var div = document.createElement('div');
+    div.className = 'key-point-item';
+    div.innerHTML =
+      '<input type="text" class="form-input" placeholder="Point title (bold)" value="' + (kp.title || '').replace(/"/g, '&quot;') + '" oninput="updateKeyPointField(' + i + ', \'title\', this.value)">' +
+      '<textarea class="form-input" placeholder="Point description" oninput="updateKeyPointField(' + i + ', \'description\', this.value)">' + (kp.description || '') + '</textarea>' +
+      '<button type="button" class="btn-remove" onclick="removeKeyPoint(' + i + ')"><i class="fas fa-times"></i></button>';
+    container.appendChild(div);
+  });
+}
+
+function addSidebarSource() {
+  sidebarSourcesData.push({ name: '', url: '' });
+  updateContentLabels();
+  renderSidebarSources();
+}
+
+function removeSidebarSource(index) {
+  sidebarSourcesData.splice(index, 1);
+  updateContentLabels();
+  renderSidebarSources();
+}
+
+function updateSidebarSourceField(index, field, value) {
+  sidebarSourcesData[index][field] = value;
+  updateContentLabels();
+}
+
+function renderSidebarSources() {
+  var container = document.getElementById('sidebarSourcesList');
+  container.innerHTML = '';
+  if (sidebarSourcesData.length === 0) {
+    container.innerHTML = '<p style="color: var(--gray-500); font-size: 14px; margin: 4px 0;">No sources added yet</p>';
+    return;
+  }
+  sidebarSourcesData.forEach(function(src, i) {
+    var div = document.createElement('div');
+    div.className = 'sidebar-source-item';
+    div.innerHTML =
+      '<input type="text" class="form-input" placeholder="Source name" value="' + (src.name || '').replace(/"/g, '&quot;') + '" oninput="updateSidebarSourceField(' + i + ', \'name\', this.value)" style="flex:0.4">' +
+      '<input type="url" class="form-input" placeholder="https://source-url.com" value="' + (src.url || '').replace(/"/g, '&quot;') + '" oninput="updateSidebarSourceField(' + i + ', \'url\', this.value)" style="flex:0.6">' +
+      '<button type="button" class="btn-remove" onclick="removeSidebarSource(' + i + ')"><i class="fas fa-times"></i></button>';
+    container.appendChild(div);
+  });
 }
 
 // ==================== Initialize on Page Load ====================

--- a/wts-admin/src/views/content/articles/form.ejs
+++ b/wts-admin/src/views/content/articles/form.ejs
@@ -2048,10 +2048,39 @@ function renderKeyPoints() {
   keyPointsData.forEach(function(kp, i) {
     var div = document.createElement('div');
     div.className = 'key-point-item';
-    div.innerHTML =
-      '<input type="text" class="form-input" placeholder="Point title (bold)" value="' + (kp.title || '').replace(/"/g, '&quot;') + '" oninput="updateKeyPointField(' + i + ', \'title\', this.value)">' +
-      '<textarea class="form-input" placeholder="Point description" oninput="updateKeyPointField(' + i + ', \'description\', this.value)">' + (kp.description || '') + '</textarea>' +
-      '<button type="button" class="btn-remove" onclick="removeKeyPoint(' + i + ')"><i class="fas fa-times"></i></button>';
+
+    var input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'form-input';
+    input.placeholder = 'Point title (bold)';
+    input.value = kp.title || '';
+    input.oninput = function() {
+      updateKeyPointField(i, 'title', this.value);
+    };
+
+    var textarea = document.createElement('textarea');
+    textarea.className = 'form-input';
+    textarea.placeholder = 'Point description';
+    textarea.value = kp.description || '';
+    textarea.oninput = function() {
+      updateKeyPointField(i, 'description', this.value);
+    };
+
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn-remove';
+    button.onclick = function() {
+      removeKeyPoint(i);
+    };
+
+    var icon = document.createElement('i');
+    icon.className = 'fas fa-times';
+    button.appendChild(icon);
+
+    div.appendChild(input);
+    div.appendChild(textarea);
+    div.appendChild(button);
+
     container.appendChild(div);
   });
 }


### PR DESCRIPTION
- Add content_labels JSONB column to articles table for structured sidebar data
- Add Content Labels form section in article editor with fields for: description, who should read (audience list), key points (title + description), sources (name + url badges), FAQs count, and custom CTA button text
- Update article create/update routes to persist content_labels
- Update public API to return content_labels in article responses
- Add sticky sidebar card to dynamic article frontend (two-column layout)
- Add sidebar card generation to static article generator
- Sidebar card renders: featured image, category tag, title, meta info, description, "Who Should Read This" bullet list, "What You'll Learn" key points, "Sources Referenced" badges, and read stats bar with CTA button
- Responsive: sidebar moves above article on screens < 960px

https://claude.ai/code/session_017sWNKFvvxPsLNnpBZzXpjJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent article sidebar card with description, audience, key takeaways, sources, read stats, and CTA; hides when no sidebar data.
  * Admin controls to manage sidebar content from the article editor.

* **UI/UX**
  * Two-column article layout (wider content area + sticky sidebar) with responsive fallback to single-column on smaller screens; increased page max width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->