### PR TITLE
Fix hover tooltip cut off + clarify admin label

### DIFF
--- a/en/digital-marketing-services/prices/index.html
+++ b/en/digital-marketing-services/prices/index.html
@@ -150,7 +150,7 @@
         .lao-card h3 { color: var(--color-accent-magenta); }
 
         /* Subscription Cards */
-        .subscription-card { text-align: center; position: relative; overflow: hidden; }
+        .subscription-card { text-align: center; position: relative; overflow: visible; }
         .subscription-card.highlight { border-color: var(--color-accent-magenta); border-width: 2px; }
 
         .popular-pill-badge { 
@@ -438,7 +438,7 @@
             font-weight: 600;
             text-align: center;
             padding: 0.4rem 1rem;
-            border-radius: 0 0 12px 12px;
+            border-radius: 0 0 24px 24px;
             margin: 1rem -2rem -2rem -2rem;
             cursor: pointer;
             transition: all 0.2s ease;

--- a/wts-admin/src/views/business/pricing/form.ejs
+++ b/wts-admin/src/views/business/pricing/form.ejs
@@ -139,9 +139,9 @@
         <div class="card-header"><h3><i class="fas fa-arrow-up"></i> Upsell Strategy</h3></div>
         <div class="card-body">
           <div class="form-group">
-            <label class="form-label" for="upsell_text">Upsell Message</label>
+            <label class="form-label" for="upsell_text">Hover Bubble Message</label>
             <input type="text" id="upsell_text" name="upsell_text" class="form-input" value="<%= model ? (model.upsell_text || '') : '' %>" placeholder="e.g. Upgrade to Professional for 3x the features!">
-            <small style="color:#666;">Shown on hover or as a nudge to guide users to the next tier</small>
+            <small style="color:#666;">This message appears in a tooltip bubble when users hover over this plan card. Leave empty to hide the bubble.</small>
           </div>
           <div class="form-group">
             <label class="form-label" for="upsell_target_id">Upsell Target Plan</label>


### PR DESCRIPTION
The upsell tooltip bubble was clipped because .subscription-card had overflow:hidden. Changed to overflow:visible so the tooltip (positioned above the card via bottom:100%) can render outside the card bounds. Updated .upsell-banner border-radius to 24px to match the card corners without needing overflow clipping.

Also renamed the admin form label from "Upsell Message" to "Hover Bubble Message" with a clearer description so it's obvious this controls the tooltip that appears on hover.

https://claude.ai/code/session_01BEshAoyS86BexJ5q8neWxd