### PR TITLE
Wire all site forms to admin backend API (replace Firebase)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -17,11 +17,10 @@ document.addEventListener('DOMContentLoaded', () => {
     quoteForm.addEventListener('submit', handleFormSubmit);
   }
 
-  // Connect the Newsletter form
-  const newsletterForm = document.getElementById('newsletter-form');
-  if (newsletterForm) {
-    newsletterForm.addEventListener('submit', handleNewsletterSubmit);
-  }
+  // Connect all Newsletter forms (by ID or class)
+  document.querySelectorAll('#newsletter-form, form.newsletter-form').forEach(form => {
+    form.addEventListener('submit', handleNewsletterSubmit);
+  });
 
   updateFooterLanguageLinks();
 });

--- a/js/modules/firebase.js
+++ b/js/modules/firebase.js
@@ -1,45 +1,94 @@
 // js/modules/firebase.js
+// Form submissions — sends to WTS Admin backend API
 
-import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
-import { getFirestore, collection, addDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+const API_BASE = 'https://admin.wordsthatsells.website/api/public';
 
-const firebaseConfig = {
-  apiKey: "AIzaSyB3ZGL1BHhZ-uk1-ZsR0-uoQ6qKroa-HLw",
-  authDomain: "wordsthatsells-website.firebaseapp.com",
-  projectId: "wordsthatsells-website",
-  storageBucket: "wordsthatsells-website.firebasestorage.app",
-  messagingSenderId: "926017355408",
-  appId: "1:926017355408:web:e9740dbc89ad4fa2b5a215",
-  measurementId: "G-9EWB7GS931"
-};
+/**
+ * Detect form_type from the modal title text.
+ * "Apply for Affiliate Program" → affiliate
+ * "leave a quick message" / anything else → general-inquiry
+ */
+function detectFormType() {
+  const modalTitle = document.querySelector('#quote-modal-container .modal-title');
+  if (modalTitle) {
+    const text = modalTitle.textContent.toLowerCase();
+    if (text.includes('affiliate')) return 'affiliate';
+  }
+  return 'general-inquiry';
+}
 
-const app = initializeApp(firebaseConfig);
-const db = getFirestore(app);
-
-// Function for the main Affiliate Program form
+// Function for the main quote/affiliate form (present on every page)
 export async function handleFormSubmit(event) {
-  event.preventDefault(); 
+  event.preventDefault();
   const form = event.target;
+  const submitBtn = form.querySelector('button[type="submit"]');
   const formData = new FormData(form);
-  const name = formData.get('name');
-  const email = formData.get('email');
-  const company = formData.get('company');
-  const service = formData.get('service');
-  const message = formData.get('message');
+
+  const name = (formData.get('name') || '').trim();
+  const email = (formData.get('email') || '').trim();
+  const company = (formData.get('company') || '').trim();
+  const service = (formData.get('service') || '').trim();
+  const message = (formData.get('message') || '').trim();
+
+  if (!name || !email) {
+    alert('Please fill in your name and email.');
+    return;
+  }
+
+  const formType = detectFormType();
+  const payload = {
+    form_type: formType,
+    name,
+    email,
+    company: company || undefined,
+    message: message || undefined,
+    metadata: service ? { service } : undefined
+  };
+
+  if (submitBtn) {
+    submitBtn.disabled = true;
+    submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Submitting...';
+  }
+
   try {
-    await addDoc(collection(db, "submissions"), {
-      name: name,
-      email: email,
-      company: company,
-      service: service,
-      message: message,
-      submittedAt: new Date()
+    const res = await fetch(`${API_BASE}/submissions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
     });
-    alert("Thank you for your submission!");
+
+    if (!res.ok) {
+      const errData = await res.json().catch(() => ({}));
+      throw new Error(errData.error || 'Submission failed.');
+    }
+
+    // GA tracking
+    if (typeof gtag === 'function') {
+      gtag('event', 'form_submit', { event_category: 'Forms', event_label: formType });
+    }
+
+    // Show success in the modal
+    const container = document.getElementById('quote-modal-container');
+    if (container) {
+      container.innerHTML = `
+        <button id="modal-close-btn" class="modal-close" aria-label="Close" onclick="document.getElementById('quote-modal-overlay').style.display='none'">×</button>
+        <div style="text-align:center;padding:2rem 1rem;">
+          <i class="fas fa-check-circle" style="font-size:3rem;color:#10b981;margin-bottom:1rem;display:block;"></i>
+          <h2 style="margin-bottom:0.5rem;">Thank You!</h2>
+          <p style="color:#64748b;">Your request has been submitted successfully. Our team will get back to you shortly.</p>
+        </div>
+      `;
+    }
+
     form.reset();
   } catch (e) {
-    console.error("Error adding document: ", e);
-    alert("There was an error submitting your form. Please try again. Error: " + e);
+    console.error('Form submission error:', e);
+    alert(e.message || 'There was an error submitting your form. Please try again.');
+  } finally {
+    if (submitBtn) {
+      submitBtn.disabled = false;
+      submitBtn.innerHTML = '<i class="fas fa-paper-plane"></i> Submit Request';
+    }
   }
 }
 
@@ -47,17 +96,50 @@ export async function handleFormSubmit(event) {
 export async function handleNewsletterSubmit(event) {
   event.preventDefault();
   const form = event.target;
+  const submitBtn = form.querySelector('button[type="submit"]');
   const formData = new FormData(form);
-  const email = formData.get('email');
+  const email = (formData.get('email') || '').trim();
+
+  if (!email) {
+    alert('Please enter your email address.');
+    return;
+  }
+
+  if (submitBtn) {
+    submitBtn.disabled = true;
+    submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Subscribing...';
+  }
+
   try {
-    await addDoc(collection(db, "newsletterSignups"), {
-      email: email,
-      signedUpAt: new Date()
+    const res = await fetch(`${API_BASE}/submissions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        form_type: 'newsletter',
+        name: email.split('@')[0],
+        email,
+        metadata: { source: window.location.pathname }
+      })
     });
-    alert("Thanks for subscribing!");
+
+    if (!res.ok) {
+      const errData = await res.json().catch(() => ({}));
+      throw new Error(errData.error || 'Subscription failed.');
+    }
+
+    if (typeof gtag === 'function') {
+      gtag('event', 'form_submit', { event_category: 'Newsletter', event_label: 'subscribe' });
+    }
+
+    alert('Thanks for subscribing! You\'ll hear from us soon.');
     form.reset();
   } catch (e) {
-    console.error("Error adding document: ", e);
-    alert("Subscription failed. Please try again.");
+    console.error('Newsletter signup error:', e);
+    alert(e.message || 'Subscription failed. Please try again.');
+  } finally {
+    if (submitBtn) {
+      submitBtn.disabled = false;
+      submitBtn.innerHTML = '<i class="fas fa-paper-plane"></i> Subscribe';
+    }
   }
 }

--- a/wts-admin/src/views/business/submissions/list.ejs
+++ b/wts-admin/src/views/business/submissions/list.ejs
@@ -34,6 +34,8 @@
             <option value="free-support" <%= activeFilter === 'free-support' ? 'selected' : '' %>>Free Support</option>
             <option value="affiliate" <%= activeFilter === 'affiliate' ? 'selected' : '' %>>Affiliate</option>
             <option value="white-label" <%= activeFilter === 'white-label' ? 'selected' : '' %>>White Label</option>
+            <option value="general-inquiry" <%= activeFilter === 'general-inquiry' ? 'selected' : '' %>>General Inquiry</option>
+            <option value="newsletter" <%= activeFilter === 'newsletter' ? 'selected' : '' %>>Newsletter</option>
           </select>
           <button type="submit" class="btn btn-secondary btn-sm">Filter</button>
           <% if (activeFilter) { %>
@@ -67,11 +69,13 @@
                   <br><span style="color: var(--color-slate-500);"><%= new Date(sub.created_at).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' }) %></span>
                 </td>
                 <td>
-                  <% const typeLabels = { 'consultation': 'Consultation', 'free-support': 'Free Support', 'affiliate': 'Affiliate', 'white-label': 'White Label' }; %>
+                  <% const typeLabels = { 'consultation': 'Consultation', 'free-support': 'Free Support', 'affiliate': 'Affiliate', 'white-label': 'White Label', 'general-inquiry': 'General Inquiry', 'newsletter': 'Newsletter' }; %>
                   <span class="status-badge" style="background:
                     <% if (sub.form_type === 'consultation') { %>#dbeafe; color:#1e40af;
                     <% } else if (sub.form_type === 'free-support') { %>#d1fae5; color:#065f46;
                     <% } else if (sub.form_type === 'affiliate') { %>#fce7f3; color:#9d174d;
+                    <% } else if (sub.form_type === 'general-inquiry') { %>#fef3c7; color:#92400e;
+                    <% } else if (sub.form_type === 'newsletter') { %>#f0fdf4; color:#166534;
                     <% } else { %>#e0e7ff; color:#3730a3;
                     <% } %>">
                     <%= typeLabels[sub.form_type] || sub.form_type %>


### PR DESCRIPTION
- Rewrite firebase.js: replace Firebase Firestore with admin API submissions
  - Quote/affiliate form detects type from modal title (affiliate vs general-inquiry)
  - Shows success message in modal instead of alert()
  - Adds loading spinner on submit buttons
  - Includes service selection in metadata JSON
- Update main.js: bind newsletter forms by class (.newsletter-form) not just ID
  - Now works on all pages (service, company, resources)
- Update public-api.js: add general-inquiry and newsletter form types
  - Accept metadata field in POST body, store in JSONB column
- Update admin submissions view: add new types to filter + color-coded badges

https://claude.ai/code/session_01BEshAoyS86BexJ5q8neWxd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support for multiple newsletter signup forms on the same page
  * Added general inquiry form type for submissions

* **Improvements**
  * Form submissions now display loading indicators during processing
  * Enhanced error handling with clearer user feedback
  * Improved form reliability and submission tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->