### PR TITLE
Fix mobile help-tab: convert rotated side tab to pill FAB on mobile

### DIFF
--- a/css/components/floating-ui.css
+++ b/css/components/floating-ui.css
@@ -100,6 +100,36 @@
     font-size: 1rem;
 }
 
+.help-tab .help-tab-label {}
+
+/* Mobile — convert rotated tab to bottom-right pill button (icon only) */
+@media (max-width: 767px) {
+    .help-tab {
+        top: auto;
+        bottom: 80px;
+        right: 16px;
+        transform: none !important;
+        transform-origin: center;
+        border-radius: 50px;
+        padding: 12px 18px;
+        font-size: 0.85rem;
+        box-shadow: 0 4px 15px rgba(214, 43, 131, 0.4);
+    }
+
+    .help-tab.show {
+        transform: none !important;
+    }
+
+    .help-tab .help-tab-label {
+        display: none;
+    }
+
+    .help-tab i {
+        font-size: 1.2rem;
+        margin: 0;
+    }
+}
+
 /* Help sidebar slide-in panel */
 #help-sidebar-overlay {
     position: fixed;

--- a/js/services/page-sidebar.js
+++ b/js/services/page-sidebar.js
@@ -45,7 +45,7 @@
     var style = document.createElement('style');
     style.id = 'page-sidebar-styles';
     style.textContent =
-      /* Floating button */
+      /* Floating button — desktop: rotated vertical tab on right edge */
       '.help-tab{position:fixed;top:28%;right:0;transform:translateY(-50%) rotate(270deg);transform-origin:bottom right;' +
       'background-color:#d62b83;color:#fff;padding:10px 20px;border-top-left-radius:8px;border-top-right-radius:8px;' +
       'cursor:pointer;z-index:999;font-weight:bold;transition:background-color .3s,opacity .3s,transform .3s;' +
@@ -54,6 +54,7 @@
       '.help-tab.show{opacity:1;transform:translateY(-50%) rotate(270deg) translateX(0);pointer-events:auto;}' +
       '.help-tab:hover{background-color:#f90784;}' +
       '.help-tab i{font-size:1rem;}' +
+      '.help-tab .help-tab-label{}' +
 
       /* Overlay */
       '#help-sidebar-overlay{position:fixed;inset:0;background:rgba(18,42,63,.6);z-index:1999;' +
@@ -84,9 +85,19 @@
       '.help-sidebar-body a{color:#d62b83;text-decoration:underline;}' +
       '.help-sidebar-body p{margin-bottom:.75rem;}' +
 
-      /* Mobile */
-      '@media(max-width:767px){#help-sidebar-panel{width:100%;max-width:none;}' +
-      '.help-sidebar-header{padding:.75rem 1rem;}.help-sidebar-body{padding:1rem;}}' +
+      /* Mobile — convert rotated tab to bottom-right pill button */
+      '@media(max-width:767px){' +
+        '.help-tab{top:auto;bottom:80px;right:16px;' +
+        'transform:none !important;transform-origin:center;' +
+        'border-radius:50px;padding:12px 18px;font-size:.85rem;' +
+        'box-shadow:0 4px 15px rgba(214,43,131,.4);}' +
+        '.help-tab.show{transform:none !important;}' +
+        '.help-tab .help-tab-label{display:none;}' +
+        '.help-tab i{font-size:1.2rem;margin:0;}' +
+        '#help-sidebar-panel{width:100%;max-width:none;}' +
+        '.help-sidebar-header{padding:.75rem 1rem;}' +
+        '.help-sidebar-body{padding:1rem;}' +
+      '}' +
 
       /* No scroll when panel open */
       'body.no-scroll{overflow:hidden;}';
@@ -100,7 +111,7 @@
     var btn = document.createElement('button');
     btn.className = 'help-tab';
     btn.id = 'help-sidebar-btn';
-    btn.innerHTML = '<i class="' + esc(panel.icon_class || 'fas fa-question-circle') + '"></i> ' + esc(panel.button_label || 'Help');
+    btn.innerHTML = '<i class="' + esc(panel.icon_class || 'fas fa-question-circle') + '"></i> <span class="help-tab-label">' + esc(panel.button_label || 'Help') + '</span>';
     document.body.appendChild(btn);
 
     // Show after scroll (same pattern as the quote-tab)


### PR DESCRIPTION
The rotated 270deg help-tab was causing horizontal overflow on mobile, forcing users to swipe left/right to see the tab. The article pages don't load reset.css (which has overflow-x:hidden on body), so the rotated element extended beyond the viewport.

On mobile (<768px), the help-tab now becomes a compact icon-only pill button fixed to the bottom-right corner (above back-to-top), with:
- No rotation (transform: none)
- Rounded pill shape (border-radius: 50px)
- Text label hidden, icon only (larger at 1.2rem)
- Magenta shadow for visibility
- Positioned at bottom:80px to clear back-to-top button

Applied to both:
- page-sidebar.js (injected CSS for standalone article pages)
- floating-ui.css (external CSS for pages using the component library)

Button label wrapped in .help-tab-label span for selective mobile hide.

https://claude.ai/code/session_01FTJchtPC2UcgxeghSSEwtb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced mobile experience by repositioning the help tab to a bottom-right pill-style button layout.
  * Optimized spacing, sizing, and visual presentation for smaller screens to improve usability and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->