### PR TITLE
Add dynamic form buttons section to all service pages

### DIFF
--- a/css/components/buttons.css
+++ b/css/components/buttons.css
@@ -81,8 +81,98 @@
     color: var(--color-white);
 }
 
+/* --- FORM BUTTON PRESETS (admin-managed CTA buttons) --- */
+.form-buttons-wrapper {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: 2rem;
+    padding: 1.5rem 0;
+}
+
+.btn-form-primary {
+    background-color: var(--color-primary-base);
+    color: var(--color-white);
+    border-color: var(--color-primary-base);
+    padding: var(--spacing-sm) var(--spacing-lg);
+    font-size: var(--font-size-lg);
+}
+.btn-form-primary:hover {
+    background-color: var(--color-indigo-300);
+    border-color: var(--color-indigo-300);
+    transform: translateY(-2px);
+}
+
+.btn-form-secondary {
+    background-color: var(--color-slate-700);
+    color: var(--color-white);
+    border-color: var(--color-slate-700);
+    padding: var(--spacing-sm) var(--spacing-lg);
+    font-size: var(--font-size-lg);
+}
+.btn-form-secondary:hover {
+    background-color: var(--color-slate-800);
+    border-color: var(--color-slate-800);
+    transform: translateY(-2px);
+}
+
+.btn-form-outline {
+    background-color: transparent;
+    color: var(--color-primary-base);
+    border-color: var(--color-primary-base);
+    padding: var(--spacing-sm) var(--spacing-lg);
+    font-size: var(--font-size-lg);
+}
+.btn-form-outline:hover {
+    background-color: var(--color-primary-base);
+    color: var(--color-white);
+    transform: translateY(-2px);
+}
+
+.btn-form-ghost {
+    background-color: rgba(31, 133, 201, 0.1);
+    color: var(--color-primary-base);
+    border-color: transparent;
+    padding: var(--spacing-sm) var(--spacing-lg);
+    font-size: var(--font-size-lg);
+}
+.btn-form-ghost:hover {
+    background-color: rgba(31, 133, 201, 0.2);
+    transform: translateY(-2px);
+}
+
+.btn-form-gradient {
+    background: linear-gradient(135deg, var(--color-primary-base) 0%, var(--color-accent-magenta) 100%);
+    color: var(--color-white);
+    border-color: transparent;
+    padding: var(--spacing-sm) var(--spacing-lg);
+    font-size: var(--font-size-lg);
+    box-shadow: var(--shadow-md);
+}
+.btn-form-gradient:hover {
+    box-shadow: var(--shadow-lg);
+    transform: translateY(-2px);
+}
+
+.btn-form-cta {
+    background-color: var(--color-accent-magenta);
+    color: var(--color-white);
+    border-color: var(--color-accent-magenta);
+    padding: var(--spacing-md) var(--spacing-xl);
+    font-size: var(--font-size-xl);
+    border-radius: var(--border-radius-full);
+    box-shadow: var(--shadow-lg);
+}
+.btn-form-cta:hover {
+    background-color: #f90784;
+    border-color: #f90784;
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-xl);
+}
+
 /* --- Icon Styling (applies to all buttons) --- */
-.btn i { 
-    margin-right: var(--spacing-sm); 
-    font-size: 1.1em; 
+.btn i {
+    margin-right: var(--spacing-sm);
+    font-size: 1.1em;
 }

--- a/en/digital-marketing-services/business-tools/index.html
+++ b/en/digital-marketing-services/business-tools/index.html
@@ -173,6 +173,9 @@
                 <div class="service-grid" data-service-page="business-tools">
                     <!-- Products loaded dynamically from admin API -->
                 </div>
+
+                <!-- Form Buttons Section (loaded dynamically from admin API) -->
+                <div class="form-buttons-section" data-buttons-page="/en/digital-marketing-services/business-tools"></div>
             </div>
         </section>
       

--- a/en/digital-marketing-services/content-creation/index.html
+++ b/en/digital-marketing-services/content-creation/index.html
@@ -173,6 +173,9 @@
                 <div class="service-grid" data-service-page="content-creation">
                     <!-- Products loaded dynamically from admin API -->
                 </div>
+
+                <!-- Form Buttons Section (loaded dynamically from admin API) -->
+                <div class="form-buttons-section" data-buttons-page="/en/digital-marketing-services/content-creation"></div>
             </div>
         </section>
       

--- a/en/digital-marketing-services/social-media-management/index.html
+++ b/en/digital-marketing-services/social-media-management/index.html
@@ -173,6 +173,9 @@
                 <div class="service-grid" data-service-page="social-media-management">
                     <!-- Products loaded dynamically from admin API -->
                 </div>
+
+                <!-- Form Buttons Section (loaded dynamically from admin API) -->
+                <div class="form-buttons-section" data-buttons-page="/en/digital-marketing-services/social-media-management"></div>
             </div>
         </section>
       

--- a/en/digital-marketing-services/web-development/index.html
+++ b/en/digital-marketing-services/web-development/index.html
@@ -173,6 +173,9 @@
                 <div class="service-grid" data-service-page="web-development">
                     <!-- Products loaded dynamically from admin API -->
                 </div>
+
+                <!-- Form Buttons Section (loaded dynamically from admin API) -->
+                <div class="form-buttons-section" data-buttons-page="/en/digital-marketing-services/web-development"></div>
             </div>
         </section>
       


### PR DESCRIPTION
Extends product-loader.js to fetch admin-managed form buttons from the public API and render them as styled CTAs on each service page. Buttons are filtered by page_url so admins control which buttons appear where. Added 6 button preset styles (primary, secondary, outline, ghost, gradient, cta) to buttons.css.

https://claude.ai/code/session_01FTJchtPC2UcgxeghSSEwtb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added form buttons section to service pages, enabling users to request quotes directly from their respective services.
  * Form buttons dynamically load and trigger a quote form modal when clicked.

* **Style**
  * Introduced multiple new button preset styles including primary, secondary, outline, ghost, gradient, and call-to-action variants, each with distinct visual designs and interactive hover states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->