### PR TITLE
Add folder organization system to Image Library

### DIFF
--- a/wts-admin/public/css/style.css
+++ b/wts-admin/public/css/style.css
@@ -2477,3 +2477,147 @@ select.form-input {
     flex-direction: column;
   }
 }
+
+/* ==================== Folder Navigation ==================== */
+
+.folder-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  color: var(--gray-700);
+  text-decoration: none;
+  font-size: 0.85rem;
+  transition: background 0.15s, color 0.15s;
+  cursor: pointer;
+}
+
+.folder-nav-item:hover {
+  background: var(--gray-100);
+  color: var(--gray-900);
+}
+
+.folder-nav-item.active {
+  background: var(--primary-light, #eff6ff);
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.folder-count {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--gray-400);
+  background: var(--gray-100);
+  padding: 1px 6px;
+  border-radius: 10px;
+  min-width: 20px;
+  text-align: center;
+}
+
+.folder-nav-item.active .folder-count {
+  background: rgba(59, 130, 246, 0.15);
+  color: var(--primary);
+}
+
+.folder-nav-item-wrapper {
+  position: relative;
+}
+
+.folder-nav-item-wrapper .folder-actions {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: none;
+  gap: 2px;
+}
+
+.folder-nav-item-wrapper:hover .folder-actions {
+  display: flex;
+}
+
+.folder-action-btn {
+  background: none;
+  border: none;
+  color: var(--gray-400);
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.folder-action-btn:hover {
+  color: var(--gray-700);
+  background: var(--gray-200);
+}
+
+/* ==================== Modal ==================== */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-card {
+  background: white;
+  border-radius: var(--radius);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  width: 100%;
+  max-width: 500px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--gray-200);
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--gray-400);
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.modal-close:hover {
+  color: var(--gray-700);
+}
+
+.modal-body {
+  padding: 20px;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--gray-200);
+}
+
+/* Responsive: stack folder sidebar below on mobile */
+@media (max-width: 768px) {
+  .page-content > div[style*="grid-template-columns: 240px"] {
+    grid-template-columns: 1fr !important;
+  }
+}

--- a/wts-admin/src/views/images/detail.ejs
+++ b/wts-admin/src/views/images/detail.ejs
@@ -53,6 +53,7 @@
                 <tr><td style="font-weight: 600;">Dimensions</td><td><%= image.width %> &times; <%= image.height %> px</td></tr>
                 <% } %>
                 <tr><td style="font-weight: 600;">Category</td><td><span class="status-badge <%= image.category %>"><%= image.category %></span></td></tr>
+                <tr><td style="font-weight: 600;">Folder</td><td><%= currentFolderName ? currentFolderName : '<span style="color:var(--gray-400);">None</span>' %></td></tr>
                 <tr><td style="font-weight: 600;">File Path</td><td style="word-break: break-all;"><code><%= image.file_path %></code></td></tr>
                 <tr><td style="font-weight: 600;">Uploaded</td><td><%= new Date(image.created_at).toLocaleDateString() %></td></tr>
               </tbody>
@@ -223,6 +224,17 @@
                     <option value="icons" <%= image.category === 'icons' ? 'selected' : '' %>>Icons</option>
                   </select>
                 </div>
+                <div class="form-group">
+                  <label class="form-label" for="folder_id">Folder</label>
+                  <select id="folder_id" name="folder_id" class="form-input">
+                    <option value="">No folder</option>
+                    <% if (folders && folders.length > 0) { folders.forEach(f => { %>
+                    <option value="<%= f.id %>" <%= image.folder_id === f.id ? 'selected' : '' %>><%= '—'.repeat(f.depth) %><%= f.depth ? ' ' : '' %><%= f.name %></option>
+                    <% }); } %>
+                  </select>
+                </div>
+              </div>
+              <div class="form-row">
                 <div class="form-group">
                   <label class="form-label" for="tags">Tags</label>
                   <input type="text" id="tags" name="tags" class="form-input" value="<%= image.tags ? image.tags.join(', ') : '' %>" placeholder="marketing, seo, laos">

--- a/wts-admin/src/views/images/library.ejs
+++ b/wts-admin/src/views/images/library.ejs
@@ -52,7 +52,7 @@
                 <span class="folder-count"><%= (folderCounts && folderCounts[folder.id]) || 0 %></span>
               </a>
               <div class="folder-actions">
-                <button type="button" class="folder-action-btn" onclick="openRenameFolderModal('<%= folder.id %>', '<%= folder.name.replace(/'/g, "\\'") %>')" title="Rename">
+                <button type="button" class="folder-action-btn" onclick="openRenameFolderModal(<%= JSON.stringify(folder.id) %>, <%= JSON.stringify(folder.name) %>)" title="Rename">
                   <i class="fas fa-pen" style="font-size: 10px;"></i>
                 </button>
                 <form action="/images/folders/<%= folder.id %>/delete" method="POST" style="display: inline;">

--- a/wts-admin/src/views/images/library.ejs
+++ b/wts-admin/src/views/images/library.ejs
@@ -17,15 +17,68 @@
             <i class="fas fa-sync-alt"></i> Sync from Disk
           </button>
         </form>
-        <a href="/images/upload" class="btn btn-primary">
+        <a href="/images/upload<%= (typeof activeFolder !== 'undefined' && activeFolder && activeFolder !== 'unfiled') ? '?folder=' + activeFolder : '' %>" class="btn btn-primary">
           <i class="fas fa-cloud-upload-alt"></i> Upload Image
         </a>
       </div>
     </div>
 
+    <!-- Folder Sidebar + Content Layout -->
+    <div style="display: grid; grid-template-columns: 240px 1fr; gap: 20px;">
+
+      <!-- Folder Sidebar -->
+      <div class="card" style="align-self: start;">
+        <div class="card-header" style="display: flex; justify-content: space-between; align-items: center; padding: 12px 16px;">
+          <strong style="font-size: 0.9rem;"><i class="fas fa-folder"></i> Folders</strong>
+          <button type="button" class="btn btn-sm btn-secondary" onclick="document.getElementById('newFolderModal').style.display='flex'" title="New Folder">
+            <i class="fas fa-plus"></i>
+          </button>
+        </div>
+        <div style="padding: 0;">
+          <a href="/images" class="folder-nav-item <%= !activeFolder ? 'active' : '' %>">
+            <i class="fas fa-images"></i> All Images
+          </a>
+          <a href="/images?folder=unfiled" class="folder-nav-item <%= activeFolder === 'unfiled' ? 'active' : '' %>">
+            <i class="fas fa-file-image"></i> Unfiled
+            <span class="folder-count"><%= unfiledCount %></span>
+          </a>
+          <% if (folders && folders.length > 0) { %>
+            <div style="border-top: 1px solid var(--gray-200); margin: 4px 0;"></div>
+            <% folders.forEach(folder => { %>
+            <div class="folder-nav-item-wrapper" style="position: relative;">
+              <a href="/images?folder=<%= folder.id %>" class="folder-nav-item <%= activeFolder === folder.id ? 'active' : '' %>" style="padding-left: <%= 16 + folder.depth * 16 %>px;">
+                <i class="fas fa-folder<%= activeFolder === folder.id ? '-open' : '' %>"></i>
+                <%= folder.name %>
+                <span class="folder-count"><%= (folderCounts && folderCounts[folder.id]) || 0 %></span>
+              </a>
+              <div class="folder-actions">
+                <button type="button" class="folder-action-btn" onclick="openRenameFolderModal('<%= folder.id %>', '<%= folder.name.replace(/'/g, "\\'") %>')" title="Rename">
+                  <i class="fas fa-pen" style="font-size: 10px;"></i>
+                </button>
+                <form action="/images/folders/<%= folder.id %>/delete" method="POST" style="display: inline;">
+                  <button type="submit" class="folder-action-btn" data-confirm-delete="Delete this folder? Images will be unassigned." title="Delete">
+                    <i class="fas fa-trash" style="font-size: 10px;"></i>
+                  </button>
+                </form>
+              </div>
+            </div>
+            <% }); %>
+          <% } %>
+        </div>
+      </div>
+
     <div class="card">
       <div class="card-header">
+        <% if (currentFolder) { %>
+        <div style="margin-bottom: 8px; display: flex; align-items: center; gap: 8px;">
+          <a href="/images" style="color: var(--gray-500); font-size: 0.85rem;"><i class="fas fa-arrow-left"></i></a>
+          <h3 style="margin: 0; font-size: 1rem;"><i class="fas fa-folder-open" style="color: var(--primary);"></i> <%= currentFolder.name %></h3>
+        </div>
+        <% } %>
         <form action="/images" method="GET" style="display: flex; gap: 12px; flex-wrap: wrap; align-items: center;">
+          <% if (activeFolder) { %>
+          <input type="hidden" name="folder" value="<%= activeFolder %>">
+          <% } %>
           <input type="text" name="search" class="form-input" placeholder="Search images..." value="<%= pagination.search || '' %>" style="width: 200px;">
           <select name="category" class="form-input" style="width: 150px;">
             <option value="">All Categories</option>
@@ -41,10 +94,10 @@
             <i class="fas fa-search"></i> Search
           </button>
           <div style="margin-left: auto; display: flex; gap: 4px;">
-            <a href="?view=grid&search=<%= pagination.search || '' %>&category=<%= pagination.category || '' %>" class="btn btn-sm <%= view === 'grid' ? 'btn-primary' : 'btn-secondary' %>" title="Grid view">
+            <a href="?view=grid&search=<%= pagination.search || '' %>&category=<%= pagination.category || '' %>&folder=<%= activeFolder || '' %>" class="btn btn-sm <%= view === 'grid' ? 'btn-primary' : 'btn-secondary' %>" title="Grid view">
               <i class="fas fa-th"></i>
             </a>
-            <a href="?view=list&search=<%= pagination.search || '' %>&category=<%= pagination.category || '' %>" class="btn btn-sm <%= view === 'list' ? 'btn-primary' : 'btn-secondary' %>" title="List view">
+            <a href="?view=list&search=<%= pagination.search || '' %>&category=<%= pagination.category || '' %>&folder=<%= activeFolder || '' %>" class="btn btn-sm <%= view === 'list' ? 'btn-primary' : 'btn-secondary' %>" title="List view">
               <i class="fas fa-list"></i>
             </a>
           </div>
@@ -164,17 +217,17 @@
           <div class="card-footer">
             <div class="pagination">
               <% if (pagination.page > 1) { %>
-              <a href="?page=<%= pagination.page - 1 %>&search=<%= pagination.search || '' %>&category=<%= pagination.category || '' %>&view=<%= view %>" class="pagination-btn">
+              <a href="?page=<%= pagination.page - 1 %>&search=<%= pagination.search || '' %>&category=<%= pagination.category || '' %>&folder=<%= pagination.folder || '' %>&view=<%= view %>" class="pagination-btn">
                 <i class="fas fa-chevron-left"></i>
               </a>
               <% } %>
               <% for (let i = 1; i <= pagination.totalPages; i++) { %>
-              <a href="?page=<%= i %>&search=<%= pagination.search || '' %>&category=<%= pagination.category || '' %>&view=<%= view %>" class="pagination-btn <%= i === pagination.page ? 'active' : '' %>">
+              <a href="?page=<%= i %>&search=<%= pagination.search || '' %>&category=<%= pagination.category || '' %>&folder=<%= pagination.folder || '' %>&view=<%= view %>" class="pagination-btn <%= i === pagination.page ? 'active' : '' %>">
                 <%= i %>
               </a>
               <% } %>
               <% if (pagination.page < pagination.totalPages) { %>
-              <a href="?page=<%= pagination.page + 1 %>&search=<%= pagination.search || '' %>&category=<%= pagination.category || '' %>&view=<%= view %>" class="pagination-btn">
+              <a href="?page=<%= pagination.page + 1 %>&search=<%= pagination.search || '' %>&category=<%= pagination.category || '' %>&folder=<%= pagination.folder || '' %>&view=<%= view %>" class="pagination-btn">
                 <i class="fas fa-chevron-right"></i>
               </a>
               <% } %>
@@ -203,12 +256,83 @@
         <% } %>
       </div>
     </div>
+
+    </div><!-- close grid layout -->
+
+  <!-- New Folder Modal -->
+  <div id="newFolderModal" class="modal-overlay" style="display: none;">
+    <div class="modal-card" style="max-width: 420px;">
+      <div class="modal-header">
+        <h3><i class="fas fa-folder-plus"></i> New Folder</h3>
+        <button type="button" onclick="this.closest('.modal-overlay').style.display='none'" class="modal-close">&times;</button>
+      </div>
+      <form action="/images/folders" method="POST">
+        <div class="modal-body">
+          <div class="form-group">
+            <label class="form-label">Folder Name *</label>
+            <input type="text" name="name" class="form-input" placeholder="e.g. Client Logos" required autofocus>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Parent Folder</label>
+            <select name="parent_id" class="form-input">
+              <option value="">None (root level)</option>
+              <% if (folders) { folders.forEach(f => { %>
+              <option value="<%= f.id %>"><%= '—'.repeat(f.depth) %><%= f.depth ? ' ' : '' %><%= f.name %></option>
+              <% }); } %>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Description</label>
+            <input type="text" name="description" class="form-input" placeholder="Optional description">
+          </div>
+          <% if (activeFolder && activeFolder !== 'unfiled') { %>
+          <input type="hidden" name="return_to" value="<%= activeFolder %>">
+          <% } %>
+        </div>
+        <div class="modal-footer">
+          <button type="button" onclick="this.closest('.modal-overlay').style.display='none'" class="btn btn-secondary">Cancel</button>
+          <button type="submit" class="btn btn-primary"><i class="fas fa-plus"></i> Create Folder</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- Rename Folder Modal -->
+  <div id="renameFolderModal" class="modal-overlay" style="display: none;">
+    <div class="modal-card" style="max-width: 420px;">
+      <div class="modal-header">
+        <h3><i class="fas fa-pen"></i> Rename Folder</h3>
+        <button type="button" onclick="this.closest('.modal-overlay').style.display='none'" class="modal-close">&times;</button>
+      </div>
+      <form id="renameFolderForm" action="" method="POST">
+        <div class="modal-body">
+          <div class="form-group">
+            <label class="form-label">New Name *</label>
+            <input type="text" name="name" id="renameFolderInput" class="form-input" required>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" onclick="this.closest('.modal-overlay').style.display='none'" class="btn btn-secondary">Cancel</button>
+          <button type="submit" class="btn btn-primary"><i class="fas fa-save"></i> Rename</button>
+        </div>
+      </form>
+    </div>
   </div>
 
   <!-- Copy URL toast -->
   <div id="copyToast" class="copy-toast">
     <i class="fas fa-check-circle"></i> CDN URL copied to clipboard
   </div>
+  </div><!-- close page-content -->
 </main>
+
+<script>
+function openRenameFolderModal(folderId, folderName) {
+  document.getElementById('renameFolderForm').action = '/images/folders/' + folderId + '/rename';
+  document.getElementById('renameFolderInput').value = folderName;
+  document.getElementById('renameFolderModal').style.display = 'flex';
+  document.getElementById('renameFolderInput').focus();
+}
+</script>
 
 <%- include('../partials/footer') %>

--- a/wts-admin/src/views/images/upload.ejs
+++ b/wts-admin/src/views/images/upload.ejs
@@ -82,6 +82,18 @@
                 <p class="form-help">Determines the subdirectory in the images folder</p>
               </div>
               <div class="form-group">
+                <label class="form-label" for="folder_id">Folder</label>
+                <select id="folder_id" name="folder_id" class="form-input">
+                  <option value="">No folder</option>
+                  <% if (folders && folders.length > 0) { folders.forEach(f => { %>
+                  <option value="<%= f.id %>" <%= preselectedFolder === f.id ? 'selected' : '' %>><%= '—'.repeat(f.depth) %><%= f.depth ? ' ' : '' %><%= f.name %></option>
+                  <% }); } %>
+                </select>
+                <p class="form-help">Organize this image into a folder</p>
+              </div>
+            </div>
+            <div class="form-row">
+              <div class="form-group">
                 <label class="form-label" for="tags">Tags</label>
                 <input type="text" id="tags" name="tags" class="form-input" placeholder="marketing, seo, laos">
                 <p class="form-help">Comma-separated tags for organization</p>


### PR DESCRIPTION
Introduces image_folders table with parent_id for nested folders. Adds folder CRUD (create, rename, delete), folder sidebar navigation in library view, folder selection on upload and detail pages, and bulk move-to-folder support. Images can be browsed by folder or filtered to show unfiled items.

https://claude.ai/code/session_01FTJchtPC2UcgxeghSSEwtb