### PR TITLE
Add bulk image selection and move-to-folder in library view

### DIFF
--- a/wts-admin/public/css/style.css
+++ b/wts-admin/public/css/style.css
@@ -2615,9 +2615,136 @@ select.form-input {
   border-top: 1px solid var(--gray-200);
 }
 
+/* ==================== Bulk Action Bar ==================== */
+
+.bulk-action-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  margin-bottom: 16px;
+  background: var(--primary-light, #eff6ff);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  border-radius: var(--radius);
+  animation: slideDown 0.2s ease;
+}
+
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.bulk-action-info {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.bulk-action-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+/* ==================== Image Select Checkbox ==================== */
+
+.image-select-checkbox {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
+.image-select-checkbox input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: var(--primary);
+}
+
+.image-select-grid {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 5;
+  background: white;
+  border-radius: 4px;
+  padding: 2px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.15);
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.image-card {
+  position: relative;
+}
+
+.image-card:hover .image-select-grid,
+.image-select-grid:has(input:checked) {
+  opacity: 1;
+}
+
+.image-card:has(.image-checkbox:checked) {
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
+  border-radius: var(--radius);
+}
+
+/* ==================== Move Folder List ==================== */
+
+.move-folder-list {
+  max-height: 300px;
+  overflow-y: auto;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius);
+}
+
+.move-folder-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--gray-100);
+  transition: background 0.1s;
+  font-size: 0.85rem;
+}
+
+.move-folder-option:last-child {
+  border-bottom: none;
+}
+
+.move-folder-option:hover {
+  background: var(--gray-50);
+}
+
+.move-folder-option input[type="radio"] {
+  accent-color: var(--primary);
+  flex-shrink: 0;
+}
+
+.move-folder-option span {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.move-folder-option span i {
+  color: var(--gray-400);
+  width: 16px;
+  text-align: center;
+}
+
 /* Responsive: stack folder sidebar below on mobile */
 @media (max-width: 768px) {
   .page-content > div[style*="grid-template-columns: 240px"] {
     grid-template-columns: 1fr !important;
+  }
+
+  .bulk-action-bar {
+    flex-direction: column;
+    gap: 8px;
+    text-align: center;
   }
 }

--- a/wts-admin/src/views/images/library.ejs
+++ b/wts-admin/src/views/images/library.ejs
@@ -107,11 +107,32 @@
       <div class="card-body">
         <% if (images.length > 0) { %>
 
+          <!-- Bulk Action Bar (hidden until selection) -->
+          <div id="bulkActionBar" class="bulk-action-bar" style="display: none;">
+            <div class="bulk-action-info">
+              <label class="image-select-checkbox" style="margin-right: 8px;">
+                <input type="checkbox" id="selectAllCheckbox" title="Select all">
+              </label>
+              <span id="bulkSelectedCount">0</span> selected
+            </div>
+            <div class="bulk-action-buttons">
+              <button type="button" class="btn btn-sm btn-primary" onclick="openMoveToFolderModal()">
+                <i class="fas fa-folder"></i> Move to Folder
+              </button>
+              <button type="button" class="btn btn-sm btn-secondary" onclick="clearSelection()">
+                <i class="fas fa-times"></i> Clear
+              </button>
+            </div>
+          </div>
+
           <% if (view === 'grid') { %>
           <!-- Grid View -->
           <div class="image-grid">
             <% images.forEach(image => { %>
-            <div class="image-card">
+            <div class="image-card" data-image-id="<%= image.id %>">
+              <label class="image-select-checkbox image-select-grid" onclick="event.stopPropagation()">
+                <input type="checkbox" class="image-checkbox" value="<%= image.id %>" onchange="updateBulkBar()">
+              </label>
               <a href="/images/<%= image.id %>" class="image-card-preview">
                 <img src="<%= image.cdn_url || ('/images-serve/' + encodeURIComponent(image.filename) + '?path=' + encodeURIComponent(image.file_path)) %>" alt="<%= image.alt_text || image.filename %>" loading="lazy">
                 <div class="image-card-overlay">
@@ -153,6 +174,7 @@
             <table class="table">
               <thead>
                 <tr>
+                  <th style="width: 36px;"><input type="checkbox" id="selectAllListCheckbox" onchange="toggleSelectAll(this.checked); updateBulkBar();" title="Select all"></th>
                   <th style="width: 60px;">Preview</th>
                   <th>Filename</th>
                   <th>Category</th>
@@ -164,7 +186,8 @@
               </thead>
               <tbody>
                 <% images.forEach(image => { %>
-                <tr>
+                <tr data-image-id="<%= image.id %>">
+                  <td><input type="checkbox" class="image-checkbox" value="<%= image.id %>" onchange="updateBulkBar()"></td>
                   <td>
                     <div class="image-table-thumb">
                       <img src="<%= image.cdn_url || ('/images-serve/' + encodeURIComponent(image.filename) + '?path=' + encodeURIComponent(image.file_path)) %>" alt="<%= image.alt_text || image.filename %>" loading="lazy">
@@ -319,6 +342,40 @@
     </div>
   </div>
 
+  <!-- Move to Folder Modal -->
+  <div id="moveToFolderModal" class="modal-overlay" style="display: none;">
+    <div class="modal-card" style="max-width: 420px;">
+      <div class="modal-header">
+        <h3><i class="fas fa-folder-open"></i> Move to Folder</h3>
+        <button type="button" onclick="this.closest('.modal-overlay').style.display='none'" class="modal-close">&times;</button>
+      </div>
+      <form id="moveToFolderForm" action="/images/move-to-folder" method="POST">
+        <div class="modal-body">
+          <p style="font-size: 13px; color: var(--gray-600); margin-bottom: 16px;">
+            Moving <strong id="moveImageCount">0</strong> image(s) to:
+          </p>
+          <div id="moveImageInputs"></div>
+          <div class="move-folder-list">
+            <label class="move-folder-option">
+              <input type="radio" name="folder_id" value="" checked>
+              <span><i class="fas fa-file-image"></i> Unfiled (remove from folder)</span>
+            </label>
+            <% if (folders && folders.length > 0) { folders.forEach(f => { %>
+            <label class="move-folder-option">
+              <input type="radio" name="folder_id" value="<%= f.id %>">
+              <span style="padding-left: <%= f.depth * 16 %>px;"><i class="fas fa-folder"></i> <%= f.name %></span>
+            </label>
+            <% }); } %>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" onclick="this.closest('.modal-overlay').style.display='none'" class="btn btn-secondary">Cancel</button>
+          <button type="submit" class="btn btn-primary"><i class="fas fa-folder-open"></i> Move</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
   <!-- Copy URL toast -->
   <div id="copyToast" class="copy-toast">
     <i class="fas fa-check-circle"></i> CDN URL copied to clipboard
@@ -333,6 +390,66 @@ function openRenameFolderModal(folderId, folderName) {
   document.getElementById('renameFolderModal').style.display = 'flex';
   document.getElementById('renameFolderInput').focus();
 }
+
+// Selection & Bulk Actions
+function getSelectedIds() {
+  return Array.from(document.querySelectorAll('.image-checkbox:checked')).map(cb => cb.value);
+}
+
+function updateBulkBar() {
+  const ids = getSelectedIds();
+  const bar = document.getElementById('bulkActionBar');
+  const count = document.getElementById('bulkSelectedCount');
+  count.textContent = ids.length;
+  bar.style.display = ids.length > 0 ? 'flex' : 'none';
+
+  // Sync "select all" checkboxes
+  const all = document.querySelectorAll('.image-checkbox');
+  const selectAllGrid = document.getElementById('selectAllCheckbox');
+  const selectAllList = document.getElementById('selectAllListCheckbox');
+  if (selectAllGrid) selectAllGrid.checked = ids.length === all.length && all.length > 0;
+  if (selectAllList) selectAllList.checked = ids.length === all.length && all.length > 0;
+}
+
+function toggleSelectAll(checked) {
+  document.querySelectorAll('.image-checkbox').forEach(cb => { cb.checked = checked; });
+  updateBulkBar();
+}
+
+function clearSelection() {
+  document.querySelectorAll('.image-checkbox').forEach(cb => { cb.checked = false; });
+  updateBulkBar();
+}
+
+function openMoveToFolderModal() {
+  const ids = getSelectedIds();
+  if (ids.length === 0) return;
+
+  document.getElementById('moveImageCount').textContent = ids.length;
+
+  // Create hidden inputs for each selected image
+  const container = document.getElementById('moveImageInputs');
+  container.innerHTML = '';
+  ids.forEach(id => {
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = 'image_ids';
+    input.value = id;
+    container.appendChild(input);
+  });
+
+  document.getElementById('moveToFolderModal').style.display = 'flex';
+}
+
+// Wire up the grid "select all" checkbox
+document.addEventListener('DOMContentLoaded', () => {
+  const selectAllGrid = document.getElementById('selectAllCheckbox');
+  if (selectAllGrid) {
+    selectAllGrid.addEventListener('change', () => {
+      toggleSelectAll(selectAllGrid.checked);
+    });
+  }
+});
 </script>
 
 <%- include('../partials/footer') %>


### PR DESCRIPTION
Adds checkboxes to grid and list views for selecting multiple images. A floating bulk action bar appears on selection with a "Move to Folder" button that opens a modal to pick the destination folder. Includes select-all, clear selection, and visual highlights for selected cards.

https://claude.ai/code/session_01FTJchtPC2UcgxeghSSEwtb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-image selection with checkboxes for both grid and list views
  * Bulk action bar displaying selected image count
  * Move selected images to folders via modal dialog
  * Select All option for quick bulk selection
  * Clear all selections in one action
  * Responsive design optimized for mobile devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->