### PR TITLE
Fix tab switching: use inline styles for reliable display toggling

### DIFF
--- a/wts-admin/src/views/content/articles/form.ejs
+++ b/wts-admin/src/views/content/articles/form.ejs
@@ -104,7 +104,7 @@
           </div>
 
           <!-- ===== TAB: CONTENT ===== -->
-          <div class="form-tab-panel active" id="panel-content">
+          <div class="form-tab-panel active" id="panel-content" style="display:block;">
           <div class="form-section">
             <h3 class="form-section-title" style="margin-bottom: 16px;">Article Content</h3>
 
@@ -192,7 +192,7 @@
           </div><!-- /panel-content -->
 
           <!-- ===== TAB: SEO ===== -->
-          <div class="form-tab-panel" id="panel-seo">
+          <div class="form-tab-panel" id="panel-seo" style="display:none;">
           <div class="form-section">
             <div style="display: flex; justify-content: space-between; align-items: center;">
               <h3 class="form-section-title" style="margin-bottom: 0;"><i class="fas fa-search"></i> SEO Settings</h3>
@@ -258,7 +258,7 @@
           </div><!-- /panel-seo -->
 
           <!-- ===== TAB: SOCIAL ===== -->
-          <div class="form-tab-panel" id="panel-social">
+          <div class="form-tab-panel" id="panel-social" style="display:none;">
           <!-- Social Preview Section -->
           <div class="form-section">
             <div style="display: flex; justify-content: space-between; align-items: center;">
@@ -490,7 +490,7 @@
           </div><!-- /panel-social -->
 
           <!-- ===== TAB: ADVANCED ===== -->
-          <div class="form-tab-panel" id="panel-advanced">
+          <div class="form-tab-panel" id="panel-advanced" style="display:none;">
           <!-- Citations / Sources Section -->
           <div class="form-section">
             <h3 class="form-section-title"><i class="fas fa-quote-right"></i> Citations &amp; Sources</h3>
@@ -2585,14 +2585,27 @@ function aiAnalyzeArticle() {
 
 // ==================== Form Tab Switching ====================
 function switchFormTab(tabName) {
+  // Update tab buttons
   var tabs = document.querySelectorAll('.form-tab');
+  for (var i = 0; i < tabs.length; i++) {
+    tabs[i].classList.remove('active');
+  }
+  var activeTab = document.querySelector('.form-tab[data-tab="' + tabName + '"]');
+  if (activeTab) activeTab.classList.add('active');
+
+  // Update panels - use inline styles for reliability
   var panels = document.querySelectorAll('.form-tab-panel');
-  for (var i = 0; i < tabs.length; i++) tabs[i].classList.remove('active');
-  for (var i = 0; i < panels.length; i++) panels[i].classList.remove('active');
-  var tab = document.querySelector('.form-tab[data-tab="' + tabName + '"]');
-  var panel = document.getElementById('panel-' + tabName);
-  if (tab) tab.classList.add('active');
-  if (panel) panel.classList.add('active');
+  for (var i = 0; i < panels.length; i++) {
+    panels[i].style.display = 'none';
+    panels[i].classList.remove('active');
+  }
+  var activePanel = document.getElementById('panel-' + tabName);
+  if (activePanel) {
+    activePanel.style.display = 'block';
+    activePanel.classList.add('active');
+  }
+
+  // Refresh previews for the active tab
   if (tabName === 'social') { updateSocialPreviews(); updateSocialScore(); }
   if (tabName === 'seo') { updateSerpPreview(); }
 }
@@ -2652,9 +2665,12 @@ function aiSuggestSection(section) {
   var excerptVal = document.getElementById('excerpt').value.trim();
   if (!titleVal && !contentVal) { alert('Please enter at least a title or content first.'); return; }
 
-  var btn = event.target.closest('button');
-  btn.disabled = true;
-  btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Analyzing...';
+  var evt = window.event || {};
+  var btn = evt.target ? evt.target.closest('button') : null;
+  if (btn) {
+    btn.disabled = true;
+    btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Analyzing...';
+  }
 
   var articleId = '<%= (typeof articleId !== "undefined" && articleId) ? articleId : "" %>';
   <% 
@@ -2679,13 +2695,11 @@ function aiSuggestSection(section) {
       } else {
         alert('AI error: ' + data.error);
       }
-      btn.disabled = false;
-      btn.innerHTML = '<i class="fas fa-robot"></i> AI Suggest ' + (section === 'seo' ? 'SEO' : 'Social');
+      if (btn) { btn.disabled = false; btn.innerHTML = '<i class="fas fa-robot"></i> AI Suggest ' + (section === 'seo' ? 'SEO' : 'Social'); }
     })
     .catch(function(err) {
       alert('AI failed: ' + err.message);
-      btn.disabled = false;
-      btn.innerHTML = '<i class="fas fa-robot"></i> AI Suggest ' + (section === 'seo' ? 'SEO' : 'Social');
+      if (btn) { btn.disabled = false; btn.innerHTML = '<i class="fas fa-robot"></i> AI Suggest ' + (section === 'seo' ? 'SEO' : 'Social'); }
     });
 }
 


### PR DESCRIPTION
- Add inline style="display:none" to non-active tab panels
- Add inline style="display:block" to active panel
- switchFormTab now sets element.style.display directly instead of relying solely on CSS class toggling
- Fix implicit 'event' reference in aiSuggestSection with null guard

https://claude.ai/code/session_01AA3etPU3svDTDBeSVsM5if