### PR TITLE
Reorganize article form: rename label, reorder fields, add Text Article

### DIFF
--- a/wts-admin/database/db.js
+++ b/wts-admin/database/db.js
@@ -228,6 +228,9 @@ const db = {
           IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='articles' AND column_name='content_labels') THEN
             ALTER TABLE articles ADD COLUMN content_labels JSONB DEFAULT '{}'::jsonb;
           END IF;
+          IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='articles' AND column_name='text_article') THEN
+            ALTER TABLE articles ADD COLUMN text_article TEXT;
+          END IF;
         END $$;
       `);
 

--- a/wts-admin/src/routes/content.js
+++ b/wts-admin/src/routes/content.js
@@ -130,7 +130,7 @@ router.post('/articles', [
   }
 
   try {
-    const { title, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels } = req.body;
+    const { title, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels, text_article } = req.body;
     const slug = createSlug(title);
     const tagsArray = tags ? tags.split(',').map(t => t.trim()).filter(t => t) : [];
     const keywordsArray = seo_keywords ? seo_keywords.split(',').map(k => k.trim()).filter(k => k) : [];
@@ -153,9 +153,9 @@ router.post('/articles', [
     }
 
     await db.query(
-      `INSERT INTO articles (title, slug, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, author_id, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34)`,
-      [title, slug, content, excerpt, category, tagsArray, seo_title, seo_description, keywordsArray, status || 'draft', featured_image, published_url, article_code, isFeatured, req.user.id, publishedAtValue, updatedAtValue, timeToRead, JSON.stringify(articleImagesArray), og_title, og_description, og_image, og_type || 'article', twitter_card || 'summary_large_image', twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta || 'index, follow', schemaMarkupJson ? JSON.stringify(schemaMarkupJson) : null, JSON.stringify(citationsArray), JSON.stringify(contentLabelsJson)]
+      `INSERT INTO articles (title, slug, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, author_id, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels, text_article)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35)`,
+      [title, slug, content, excerpt, category, tagsArray, seo_title, seo_description, keywordsArray, status || 'draft', featured_image, published_url, article_code, isFeatured, req.user.id, publishedAtValue, updatedAtValue, timeToRead, JSON.stringify(articleImagesArray), og_title, og_description, og_image, og_type || 'article', twitter_card || 'summary_large_image', twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta || 'index, follow', schemaMarkupJson ? JSON.stringify(schemaMarkupJson) : null, JSON.stringify(citationsArray), JSON.stringify(contentLabelsJson), text_article || null]
     );
 
     req.session.successMessage = 'Article created successfully';
@@ -210,7 +210,7 @@ router.get('/articles/:id/edit', async (req, res) => {
 // Update article
 router.post('/articles/:id', async (req, res) => {
   try {
-    const { title, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels } = req.body;
+    const { title, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels, text_article } = req.body;
 
     // Validate required fields
     if (!title || !title.trim()) {
@@ -256,9 +256,9 @@ router.post('/articles/:id', async (req, res) => {
            twitter_card = $23, twitter_title = $24, twitter_description = $25,
            twitter_image = $26, twitter_site = $27, twitter_creator = $28,
            canonical_url = $29, robots_meta = $30, schema_markup = $31,
-           citations = $32::jsonb, content_labels = $33::jsonb
+           citations = $32::jsonb, content_labels = $33::jsonb, text_article = $34
        WHERE id = $18 RETURNING id`,
-      [title, content, excerpt, category, tagsArray, seo_title, seo_description, keywordsArray, status, featured_image, published_url, isFeatured, updatedAtValue, publishedAtValue, timeToRead, article_code, JSON.stringify(articleImagesArray), req.params.id, og_title, og_description, og_image, og_type || 'article', twitter_card || 'summary_large_image', twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta || 'index, follow', schemaMarkupJson ? JSON.stringify(schemaMarkupJson) : null, JSON.stringify(citationsArray), JSON.stringify(contentLabelsJson)]
+      [title, content, excerpt, category, tagsArray, seo_title, seo_description, keywordsArray, status, featured_image, published_url, isFeatured, updatedAtValue, publishedAtValue, timeToRead, article_code, JSON.stringify(articleImagesArray), req.params.id, og_title, og_description, og_image, og_type || 'article', twitter_card || 'summary_large_image', twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta || 'index, follow', schemaMarkupJson ? JSON.stringify(schemaMarkupJson) : null, JSON.stringify(citationsArray), JSON.stringify(contentLabelsJson), text_article || null]
     );
 
     if (result.rowCount === 0) {

--- a/wts-admin/src/routes/public-api.js
+++ b/wts-admin/src/routes/public-api.js
@@ -38,7 +38,7 @@ router.get('/articles', async (req, res) => {
              og_title, og_description, og_image, og_type,
              twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator,
              canonical_url, robots_meta, schema_markup, article_images, citations,
-             time_to_read, seo_keywords, content_labels
+             time_to_read, seo_keywords, content_labels, text_article
       FROM articles
       WHERE status = 'published'
     `;
@@ -67,6 +67,7 @@ router.get('/articles', async (req, res) => {
       featured: article.featured || false,
       sidebar_content: article.excerpt || article.content?.substring(0, 500) || '',
       full_article_content: article.content,
+      text_article: article.text_article || '',
       published_url: article.published_url || '',
       article_images: article.article_images || [],
       citations: article.citations || [],
@@ -126,6 +127,7 @@ router.get('/articles/:slug', async (req, res) => {
       featured: article.featured || false,
       published_url: article.published_url || '',
       full_article_content: article.content,
+      text_article: article.text_article || '',
       time_to_read: article.time_to_read || null,
       article_images: article.article_images || [],
       citations: article.citations || [],

--- a/wts-admin/src/views/content/articles/form.ejs
+++ b/wts-admin/src/views/content/articles/form.ejs
@@ -119,12 +119,6 @@
             </div>
 
             <div class="form-group">
-              <label class="form-label" for="content"><i class="fas fa-file-code"></i> Full Article HTML *</label>
-              <textarea id="content" name="content" class="form-input" rows="15" required><%= article ? article.content : '' %></textarea>
-              <p class="form-help">The full HTML content of your article as it appears on the published page.</p>
-            </div>
-
-            <div class="form-group">
               <label class="form-label" for="featured_image"><i class="fas fa-image"></i> Featured Image</label>
               <div class="featured-image-picker" id="featuredImagePicker">
                 <div id="featuredImagePreview" class="featured-image-preview" style="<%= article && article.featured_image ? '' : 'display:none;' %>">
@@ -142,6 +136,18 @@
                   <input type="url" id="featured_image" name="featured_image" class="form-input" placeholder="Or paste image URL" value="<%= article ? article.featured_image : '' %>" style="flex: 1; font-size: 13px;">
                 </div>
               </div>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="text_article"><i class="fas fa-file-alt"></i> Text Article</label>
+              <textarea id="text_article" name="text_article" class="form-input" rows="15" placeholder="Enter the main article text content here"><%= article ? article.text_article : '' %></textarea>
+              <p class="form-help">The main text content of your article.</p>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="content"><i class="fas fa-file-code"></i> Sidemenu Content *</label>
+              <textarea id="content" name="content" class="form-input" rows="15" required><%= article ? article.content : '' %></textarea>
+              <p class="form-help">HTML content displayed in the slide-in sidebar panel when the article is previewed.</p>
             </div>
 
             <div class="form-group">


### PR DESCRIPTION
1. Rename "Full Article HTML" label to "Sidemenu Content" to clarify that this field powers the slide-in sidebar panel
2. Move Featured Image up to 3rd position (right after Excerpt)
3. Add new "Text Article" textarea between Featured Image and Sidemenu Content for main article text content
4. Add text_article column to articles table (auto-migration)
5. Wire text_article into INSERT and UPDATE queries in content routes
6. Expose text_article in both public API endpoints

New Content tab field order:
  Title > Excerpt > Featured Image > Text Article > Sidemenu Content

https://claude.ai/code/session_01AA3etPU3svDTDBeSVsM5if

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated Text Article field for main article content in article creation and editing
  * Articles API responses now include text article data

* **Changes**
  * Form interface updated: Full Article HTML field replaced with separate Text Article and Sidemenu Content fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->