### PR TITLE
feat: add multi-language "Listen to this Article" audio widget

### DIFF
--- a/admin/blog-admin.html
+++ b/admin/blog-admin.html
@@ -697,11 +697,27 @@
       const row = document.createElement('div');
       row.className = 'audio-lang-row';
       row.dataset.lang = code;
-      row.innerHTML = `
-        <label>${label}</label>
-        <input type="url" name="audio_${code}" placeholder="https://cdn.example.com/audio/article-${code}.mp3" />
-        <button type="button" class="audio-remove-btn" title="Remove language" onclick="removeAudioLang(this)">&times;</button>
-      `;
+
+      const labelEl = document.createElement('label');
+      labelEl.textContent = label;
+      row.appendChild(labelEl);
+
+      const inputEl = document.createElement('input');
+      inputEl.type = 'url';
+      inputEl.name = 'audio_' + code;
+      inputEl.placeholder = 'https://cdn.example.com/audio/article-' + code + '.mp3';
+      row.appendChild(inputEl);
+
+      const btnEl = document.createElement('button');
+      btnEl.type = 'button';
+      btnEl.className = 'audio-remove-btn';
+      btnEl.title = 'Remove language';
+      btnEl.innerHTML = '&times;';
+      btnEl.addEventListener('click', function () {
+        window.removeAudioLang(btnEl);
+      });
+      row.appendChild(btnEl);
+
       audioLangRows.appendChild(row);
     }
 

--- a/admin/blog-admin.html
+++ b/admin/blog-admin.html
@@ -222,6 +222,133 @@
     .back-link:hover {
       text-decoration: underline;
     }
+
+    /* Audio Section */
+    .audio-section {
+      border: 1px solid #e0e7ff;
+      background: #f8faff;
+      border-radius: 6px;
+      padding: 20px;
+      margin-bottom: 20px;
+    }
+
+    .audio-section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 16px;
+    }
+
+    .audio-section-title {
+      font-size: 16px;
+      font-weight: 600;
+      color: #1f3a5f;
+    }
+
+    .toggle-switch {
+      position: relative;
+      display: inline-block;
+      width: 44px;
+      height: 24px;
+    }
+
+    .toggle-switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .toggle-slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: #ccc;
+      border-radius: 24px;
+      transition: 0.3s;
+    }
+
+    .toggle-slider::before {
+      content: "";
+      position: absolute;
+      height: 18px;
+      width: 18px;
+      left: 3px;
+      bottom: 3px;
+      background: white;
+      border-radius: 50%;
+      transition: 0.3s;
+    }
+
+    .toggle-switch input:checked + .toggle-slider {
+      background: #0066cc;
+    }
+
+    .toggle-switch input:checked + .toggle-slider::before {
+      transform: translateX(20px);
+    }
+
+    .audio-fields {
+      display: none;
+    }
+
+    .audio-fields.visible {
+      display: block;
+    }
+
+    .audio-lang-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 10px;
+    }
+
+    .audio-lang-row label {
+      min-width: 70px;
+      margin-bottom: 0;
+      font-weight: 600;
+      font-size: 13px;
+      color: #555;
+    }
+
+    .audio-lang-row input {
+      flex: 1;
+    }
+
+    .audio-add-lang {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      background: none;
+      border: 1px dashed #0066cc;
+      color: #0066cc;
+      padding: 6px 14px;
+      border-radius: 4px;
+      font-size: 13px;
+      cursor: pointer;
+      margin-top: 6px;
+    }
+
+    .audio-add-lang:hover {
+      background: #e8f0fe;
+    }
+
+    .audio-remove-btn {
+      background: none;
+      border: none;
+      color: #dc3545;
+      cursor: pointer;
+      font-size: 18px;
+      padding: 4px 8px;
+      line-height: 1;
+    }
+
+    .audio-remove-btn:hover {
+      background: #fff0f0;
+      border-radius: 4px;
+    }
   </style>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMRKC1VBBB"></script>
@@ -300,6 +427,49 @@
         />
         <div class="helper-text">
           Use Unsplash, your own CDN, or leave blank for placeholder image
+        </div>
+      </div>
+
+      <!-- Audio Widget Controls -->
+      <div class="audio-section">
+        <div class="audio-section-header">
+          <span class="audio-section-title">Article Audio (Listen to this Article)</span>
+          <label class="toggle-switch">
+            <input type="checkbox" id="audio_enabled" name="audio_enabled" />
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+        <div class="helper-text" style="margin-bottom:12px">
+          Enable to attach multi-language audio files. The audio widget will appear beneath the article title.
+        </div>
+        <div class="audio-fields" id="audioFields">
+          <div id="audioLangRows">
+            <div class="audio-lang-row" data-lang="en">
+              <label>English</label>
+              <input type="url" name="audio_en" placeholder="https://cdn.example.com/audio/article-en.mp3" />
+              <button type="button" class="audio-remove-btn" title="Remove language" onclick="removeAudioLang(this)">&times;</button>
+            </div>
+            <div class="audio-lang-row" data-lang="lo">
+              <label>Lao</label>
+              <input type="url" name="audio_lo" placeholder="https://cdn.example.com/audio/article-lo.mp3" />
+              <button type="button" class="audio-remove-btn" title="Remove language" onclick="removeAudioLang(this)">&times;</button>
+            </div>
+          </div>
+          <button type="button" class="audio-add-lang" id="addAudioLangBtn">+ Add Language</button>
+          <div id="addLangDropdown" style="display:none; margin-top:8px;">
+            <select id="newLangSelect" style="padding:8px; border:1px solid #ddd; border-radius:4px; font-size:13px;">
+              <option value="">-- Select language --</option>
+              <option value="th">Thai</option>
+              <option value="es">Spanish</option>
+              <option value="fr">French</option>
+              <option value="zh">Chinese</option>
+              <option value="ja">Japanese</option>
+              <option value="ko">Korean</option>
+              <option value="vi">Vietnamese</option>
+              <option value="km">Khmer</option>
+              <option value="my">Burmese</option>
+            </select>
+          </div>
         </div>
       </div>
 
@@ -488,6 +658,100 @@
         localStorage.removeItem(`draft_${inputId}`);
       });
     });
+
+    // ==================== AUDIO CONTROLS ====================
+    const LANG_LABELS = {
+      en: 'English', lo: 'Lao', th: 'Thai', es: 'Spanish',
+      fr: 'French', zh: 'Chinese', ja: 'Japanese', ko: 'Korean',
+      vi: 'Vietnamese', km: 'Khmer', my: 'Burmese'
+    };
+
+    const audioEnabledToggle = document.getElementById('audio_enabled');
+    const audioFieldsPanel = document.getElementById('audioFields');
+    const audioLangRows = document.getElementById('audioLangRows');
+    const addAudioLangBtn = document.getElementById('addAudioLangBtn');
+    const addLangDropdown = document.getElementById('addLangDropdown');
+    const newLangSelect = document.getElementById('newLangSelect');
+
+    // Toggle audio panel visibility
+    audioEnabledToggle.addEventListener('change', () => {
+      audioFieldsPanel.classList.toggle('visible', audioEnabledToggle.checked);
+    });
+
+    // Show/hide add language dropdown
+    addAudioLangBtn.addEventListener('click', () => {
+      addLangDropdown.style.display = addLangDropdown.style.display === 'none' ? 'block' : 'none';
+      updateLangDropdownOptions();
+    });
+
+    // Add new language row when selected
+    newLangSelect.addEventListener('change', () => {
+      const code = newLangSelect.value;
+      if (!code) return;
+      addAudioLangRow(code, LANG_LABELS[code] || code);
+      newLangSelect.value = '';
+      addLangDropdown.style.display = 'none';
+    });
+
+    function addAudioLangRow(code, label) {
+      const row = document.createElement('div');
+      row.className = 'audio-lang-row';
+      row.dataset.lang = code;
+      row.innerHTML = `
+        <label>${label}</label>
+        <input type="url" name="audio_${code}" placeholder="https://cdn.example.com/audio/article-${code}.mp3" />
+        <button type="button" class="audio-remove-btn" title="Remove language" onclick="removeAudioLang(this)">&times;</button>
+      `;
+      audioLangRows.appendChild(row);
+    }
+
+    function updateLangDropdownOptions() {
+      const existing = Array.from(audioLangRows.querySelectorAll('[data-lang]')).map(r => r.dataset.lang);
+      newLangSelect.querySelectorAll('option').forEach(opt => {
+        if (opt.value) opt.disabled = existing.includes(opt.value);
+      });
+    }
+
+    // Remove a language row (global function for onclick)
+    window.removeAudioLang = function(btn) {
+      btn.closest('.audio-lang-row').remove();
+    };
+
+    // Collect audio data for form submission
+    function getAudioFilesData() {
+      if (!audioEnabledToggle.checked) return {};
+      const data = { _enabled: true };
+      audioLangRows.querySelectorAll('.audio-lang-row').forEach(row => {
+        const code = row.dataset.lang;
+        const url = row.querySelector('input[type="url"]').value.trim();
+        if (url) data[code] = url;
+      });
+      return data;
+    }
+
+    // Patch the existing submit handler to include audio_files
+    const originalSubmitHandler = form.onsubmit;
+    const submitBtnEl = document.getElementById('submitBtn');
+
+    // Override — intercept the form submit to add audio data
+    const origFormListeners = form._events;
+    form.addEventListener('submit', async (e) => {
+      // The existing handler already prevents default and handles submission.
+      // We need to patch it. Instead, let's override by removing and re-adding.
+    }, true);
+
+    // Monkey-patch: wrap the fetch body to include audio_files
+    const originalFetch = window.fetch;
+    window.fetch = function(url, options) {
+      if (typeof url === 'string' && url.includes('/api/articles') && options && options.method === 'POST') {
+        try {
+          const body = JSON.parse(options.body);
+          body.audio_files = getAudioFilesData();
+          options.body = JSON.stringify(body);
+        } catch(e) { /* ignore */ }
+      }
+      return originalFetch.call(this, url, options);
+    };
   </script>
 </body>
 </html>

--- a/js/components/article-audio-widget.html
+++ b/js/components/article-audio-widget.html
@@ -1,0 +1,479 @@
+<!--
+  ============================================================
+  "Listen to this Article" Multi-Language Audio Widget
+  ============================================================
+  Drop-in component — place this block directly beneath an
+  article's <h1> tag.  Zero framework dependencies.
+
+  SETUP:
+  1. Edit the AUDIO_TRACKS object below to map language codes
+     to their MP3/WAV URLs.
+  2. Optionally update the ARTICLE_META object for JSON-LD.
+  3. Paste this entire block into your article HTML.
+  ============================================================
+-->
+
+<!-- ==================== JSON-LD AudioObject Schema ==================== -->
+<script type="application/ld+json" id="audio-widget-schema">
+{
+  "@context": "https://schema.org",
+  "@type": "AudioObject",
+  "name": "Listen to this Article",
+  "description": "Audio version of this article",
+  "encodingFormat": "audio/mpeg",
+  "inLanguage": "en",
+  "contentUrl": ""
+}
+</script>
+
+<!-- ==================== Widget Markup ==================== -->
+<figure class="article-audio-widget" role="region" aria-label="Listen to this article in multiple languages">
+  <figcaption class="aaw-caption" id="aaw-figcaption">
+    <svg class="aaw-icon-headphones" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 18v-6a9 9 0 0118 0v6"/><path d="M21 19a2 2 0 01-2 2h-1a2 2 0 01-2-2v-3a2 2 0 012-2h3zM3 19a2 2 0 002 2h1a2 2 0 002-2v-3a2 2 0 00-2-2H3z"/></svg>
+    <span>Listen to this article</span>
+  </figcaption>
+
+  <div class="aaw-controls">
+    <!-- Language selector -->
+    <div class="aaw-lang-wrapper">
+      <label for="aaw-lang-select" class="aaw-sr-only">Select language</label>
+      <select id="aaw-lang-select" class="aaw-lang-select" aria-label="Audio language">
+        <!-- Populated by JS -->
+      </select>
+    </div>
+
+    <!-- Play / Pause -->
+    <button class="aaw-play-btn" id="aaw-play-btn" aria-label="Play audio" type="button">
+      <svg class="aaw-icon-play" id="aaw-icon-play" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><polygon points="5,3 19,12 5,21"/></svg>
+      <svg class="aaw-icon-pause" id="aaw-icon-pause" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" style="display:none"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
+    </button>
+
+    <!-- Time + Scrubber -->
+    <span class="aaw-time" id="aaw-time-current">0:00</span>
+    <div class="aaw-progress-wrap" id="aaw-progress-wrap" role="slider" aria-label="Audio progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" tabindex="0">
+      <div class="aaw-progress-track">
+        <div class="aaw-progress-fill" id="aaw-progress-fill"></div>
+      </div>
+    </div>
+    <span class="aaw-time" id="aaw-time-total">0:00</span>
+  </div>
+
+  <!-- Hidden audio element — background playback by default -->
+  <audio id="aaw-audio" preload="metadata"></audio>
+</figure>
+
+<!-- ==================== Styles ==================== -->
+<style>
+/* === Audio Widget Reset === */
+.article-audio-widget,
+.article-audio-widget *,
+.article-audio-widget *::before,
+.article-audio-widget *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+.article-audio-widget {
+  --aaw-bg: #f8fafc;
+  --aaw-border: #e2e8f0;
+  --aaw-text: #334155;
+  --aaw-text-muted: #94a3b8;
+  --aaw-accent: #2563eb;
+  --aaw-accent-hover: #1d4ed8;
+  --aaw-track-bg: #cbd5e1;
+  --aaw-radius: 999px;
+  --aaw-radius-md: 10px;
+  --aaw-font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: var(--aaw-bg);
+  border: 1px solid var(--aaw-border);
+  border-radius: var(--aaw-radius-md);
+  padding: 14px 18px;
+  margin: 20px 0 28px;
+  font-family: var(--aaw-font);
+  max-width: 100%;
+}
+
+/* Caption / heading */
+.aaw-caption {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--aaw-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.aaw-icon-headphones {
+  flex-shrink: 0;
+  color: var(--aaw-accent);
+}
+
+/* Controls row */
+.aaw-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* Language selector */
+.aaw-lang-wrapper {
+  flex-shrink: 0;
+}
+
+.aaw-lang-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background: #ffffff;
+  border: 1px solid var(--aaw-border);
+  border-radius: var(--aaw-radius);
+  padding: 6px 28px 6px 12px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--aaw-text);
+  cursor: pointer;
+  font-family: var(--aaw-font);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2364748b' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  transition: border-color 0.2s;
+}
+.aaw-lang-select:hover,
+.aaw-lang-select:focus {
+  border-color: var(--aaw-accent);
+  outline: none;
+}
+
+/* Play button */
+.aaw-play-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: none;
+  background: var(--aaw-accent);
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.15s;
+}
+.aaw-play-btn:hover {
+  background: var(--aaw-accent-hover);
+  transform: scale(1.06);
+}
+.aaw-play-btn:active {
+  transform: scale(0.96);
+}
+
+.aaw-icon-play {
+  margin-left: 2px; /* optical centre */
+}
+
+/* Time labels */
+.aaw-time {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--aaw-text-muted);
+  min-width: 34px;
+  text-align: center;
+  user-select: none;
+}
+
+/* Progress / scrubber */
+.aaw-progress-wrap {
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+  padding: 6px 0;
+  -webkit-tap-highlight-color: transparent;
+}
+.aaw-progress-track {
+  position: relative;
+  height: 5px;
+  background: var(--aaw-track-bg);
+  border-radius: var(--aaw-radius);
+  overflow: hidden;
+}
+.aaw-progress-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 0%;
+  background: var(--aaw-accent);
+  border-radius: var(--aaw-radius);
+  transition: width 0.15s linear;
+}
+.aaw-progress-wrap:hover .aaw-progress-track {
+  height: 7px;
+}
+
+/* Screen-reader only utility */
+.aaw-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .article-audio-widget {
+    padding: 12px 14px;
+  }
+  .aaw-controls {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .aaw-lang-wrapper {
+    order: -1;
+    width: 100%;
+  }
+  .aaw-lang-select {
+    width: 100%;
+  }
+}
+</style>
+
+<!-- ==================== JavaScript ==================== -->
+<script>
+(function () {
+  'use strict';
+
+  // ============================================================
+  // CONFIGURATION — edit these to match your article
+  // ============================================================
+
+  /**
+   * Map language codes to audio file URLs.
+   * Add or remove entries as needed.
+   * Keys   = ISO 639-1 codes  (used in schema inLanguage)
+   * Values = { label: display name, url: audio file URL }
+   */
+  const AUDIO_TRACKS = {
+    en: {
+      label: 'English',
+      url: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3'
+    },
+    lo: {
+      label: 'Lao',
+      url: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3'
+    },
+    th: {
+      label: 'Thai',
+      url: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3'
+    },
+    es: {
+      label: 'Spanish',
+      url: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-4.mp3'
+    }
+  };
+
+  /** Optional metadata for richer JSON-LD */
+  const ARTICLE_META = {
+    name: document.querySelector('h1')
+      ? document.querySelector('h1').textContent
+      : 'Article Audio',
+    description: document.querySelector('meta[name="description"]')
+      ? document.querySelector('meta[name="description"]').getAttribute('content')
+      : ''
+  };
+
+  // ============================================================
+  // DOM REFERENCES
+  // ============================================================
+  const audio         = document.getElementById('aaw-audio');
+  const playBtn       = document.getElementById('aaw-play-btn');
+  const iconPlay      = document.getElementById('aaw-icon-play');
+  const iconPause     = document.getElementById('aaw-icon-pause');
+  const langSelect    = document.getElementById('aaw-lang-select');
+  const timeCurrent   = document.getElementById('aaw-time-current');
+  const timeTotal     = document.getElementById('aaw-time-total');
+  const progressWrap  = document.getElementById('aaw-progress-wrap');
+  const progressFill  = document.getElementById('aaw-progress-fill');
+  const schemaScript  = document.getElementById('audio-widget-schema');
+
+  // ============================================================
+  // HELPERS
+  // ============================================================
+
+  /** Format seconds → m:ss */
+  function fmtTime(s) {
+    if (!s || !isFinite(s)) return '0:00';
+    const m = Math.floor(s / 60);
+    const sec = Math.floor(s % 60);
+    return m + ':' + (sec < 10 ? '0' : '') + sec;
+  }
+
+  /** Update JSON-LD AudioObject schema dynamically */
+  function updateSchema(langCode, url) {
+    try {
+      const schema = JSON.parse(schemaScript.textContent);
+      schema.name = ARTICLE_META.name + ' (' + (AUDIO_TRACKS[langCode]?.label || langCode) + ')';
+      schema.description = ARTICLE_META.description;
+      schema.inLanguage = langCode;
+      schema.contentUrl = url;
+      schemaScript.textContent = JSON.stringify(schema, null, 2);
+    } catch (_) { /* schema update is non-critical */ }
+  }
+
+  // ============================================================
+  // INITIALISE LANGUAGE DROPDOWN
+  // ============================================================
+  const langCodes = Object.keys(AUDIO_TRACKS);
+
+  langCodes.forEach(function (code) {
+    const opt = document.createElement('option');
+    opt.value = code;
+    opt.textContent = AUDIO_TRACKS[code].label;
+    langSelect.appendChild(opt);
+  });
+
+  // Load first track
+  if (langCodes.length > 0) {
+    const firstCode = langCodes[0];
+    audio.src = AUDIO_TRACKS[firstCode].url;
+    updateSchema(firstCode, AUDIO_TRACKS[firstCode].url);
+  }
+
+  // ============================================================
+  // LANGUAGE SWITCH
+  // ============================================================
+  langSelect.addEventListener('change', function () {
+    var code = langSelect.value;
+    var track = AUDIO_TRACKS[code];
+    if (!track) return;
+
+    var wasPlaying = !audio.paused;
+    audio.pause();
+    audio.src = track.url;
+    audio.load();
+    progressFill.style.width = '0%';
+    timeCurrent.textContent = '0:00';
+    timeTotal.textContent = '0:00';
+    setPlayIcon(false);
+
+    updateSchema(code, track.url);
+
+    // ---- Analytics: language_changed ----
+    // Replace this console.log with your GA4 dataLayer.push():
+    // window.dataLayer = window.dataLayer || [];
+    // window.dataLayer.push({ event: 'audio_language_changed', audio_language: code });
+    console.log('[AudioWidget] language_changed:', code);
+  });
+
+  // ============================================================
+  // PLAY / PAUSE
+  // ============================================================
+  function setPlayIcon(playing) {
+    iconPlay.style.display  = playing ? 'none'  : 'block';
+    iconPause.style.display = playing ? 'block' : 'none';
+    playBtn.setAttribute('aria-label', playing ? 'Pause audio' : 'Play audio');
+  }
+
+  playBtn.addEventListener('click', function () {
+    if (audio.paused) {
+      audio.play().catch(function () { /* autoplay blocked — user must interact */ });
+    } else {
+      audio.pause();
+    }
+  });
+
+  audio.addEventListener('play', function () {
+    setPlayIcon(true);
+    // ---- Analytics: play ----
+    // window.dataLayer.push({ event: 'audio_play', audio_language: langSelect.value });
+    console.log('[AudioWidget] play — lang:', langSelect.value);
+  });
+
+  audio.addEventListener('pause', function () {
+    setPlayIcon(false);
+    // ---- Analytics: pause ----
+    // window.dataLayer.push({ event: 'audio_pause', audio_language: langSelect.value, audio_position: audio.currentTime });
+    console.log('[AudioWidget] pause — lang:', langSelect.value, 'at', fmtTime(audio.currentTime));
+  });
+
+  audio.addEventListener('ended', function () {
+    setPlayIcon(false);
+    progressFill.style.width = '100%';
+    // ---- Analytics: ended ----
+    // window.dataLayer.push({ event: 'audio_ended', audio_language: langSelect.value });
+    console.log('[AudioWidget] ended — lang:', langSelect.value);
+  });
+
+  // ============================================================
+  // PROGRESS & TIME UPDATES
+  // ============================================================
+  audio.addEventListener('loadedmetadata', function () {
+    timeTotal.textContent = fmtTime(audio.duration);
+  });
+
+  audio.addEventListener('timeupdate', function () {
+    if (!audio.duration) return;
+    var pct = (audio.currentTime / audio.duration) * 100;
+    progressFill.style.width = pct + '%';
+    timeCurrent.textContent = fmtTime(audio.currentTime);
+    progressWrap.setAttribute('aria-valuenow', Math.round(pct));
+  });
+
+  // ============================================================
+  // SCRUBBER INTERACTION (mouse + touch + keyboard)
+  // ============================================================
+  function seekFromEvent(e) {
+    var rect = progressWrap.getBoundingClientRect();
+    var clientX = e.touches ? e.touches[0].clientX : e.clientX;
+    var pct = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+    if (audio.duration && isFinite(audio.duration)) {
+      audio.currentTime = pct * audio.duration;
+    }
+  }
+
+  var isScrubbing = false;
+
+  progressWrap.addEventListener('mousedown', function (e) {
+    isScrubbing = true;
+    seekFromEvent(e);
+  });
+  document.addEventListener('mousemove', function (e) {
+    if (isScrubbing) seekFromEvent(e);
+  });
+  document.addEventListener('mouseup', function () {
+    isScrubbing = false;
+  });
+
+  progressWrap.addEventListener('touchstart', function (e) {
+    isScrubbing = true;
+    seekFromEvent(e);
+  }, { passive: true });
+  progressWrap.addEventListener('touchmove', function (e) {
+    if (isScrubbing) seekFromEvent(e);
+  }, { passive: true });
+  progressWrap.addEventListener('touchend', function () {
+    isScrubbing = false;
+  });
+
+  // Keyboard: left/right arrows to seek +-5s
+  progressWrap.addEventListener('keydown', function (e) {
+    if (e.key === 'ArrowRight') {
+      audio.currentTime = Math.min(audio.duration || 0, audio.currentTime + 5);
+    } else if (e.key === 'ArrowLeft') {
+      audio.currentTime = Math.max(0, audio.currentTime - 5);
+    }
+  });
+
+})();
+</script>

--- a/wts-admin/database/db.js
+++ b/wts-admin/database/db.js
@@ -231,6 +231,9 @@ const db = {
           IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='articles' AND column_name='text_article') THEN
             ALTER TABLE articles ADD COLUMN text_article TEXT;
           END IF;
+          IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='articles' AND column_name='audio_files') THEN
+            ALTER TABLE articles ADD COLUMN audio_files JSONB DEFAULT '{}'::jsonb;
+          END IF;
         END $$;
       `);
 

--- a/wts-admin/src/routes/content.js
+++ b/wts-admin/src/routes/content.js
@@ -130,7 +130,7 @@ router.post('/articles', [
   }
 
   try {
-    const { title, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels, text_article } = req.body;
+    const { title, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels, text_article, audio_files } = req.body;
     const slug = createSlug(title);
     const tagsArray = tags ? tags.split(',').map(t => t.trim()).filter(t => t) : [];
     const keywordsArray = seo_keywords ? seo_keywords.split(',').map(k => k.trim()).filter(k => k) : [];
@@ -151,11 +151,15 @@ router.post('/articles', [
     if (content_labels && content_labels.trim()) {
       try { contentLabelsJson = JSON.parse(content_labels); } catch(e) { contentLabelsJson = {}; }
     }
+    let audioFilesJson = {};
+    if (audio_files && audio_files.trim()) {
+      try { audioFilesJson = JSON.parse(audio_files); } catch(e) { audioFilesJson = {}; }
+    }
 
     await db.query(
-      `INSERT INTO articles (title, slug, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, author_id, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels, text_article)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35)`,
-      [title, slug, content, excerpt, category, tagsArray, seo_title, seo_description, keywordsArray, status || 'draft', featured_image, published_url, article_code, isFeatured, req.user.id, publishedAtValue, updatedAtValue, timeToRead, JSON.stringify(articleImagesArray), og_title, og_description, og_image, og_type || 'article', twitter_card || 'summary_large_image', twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta || 'index, follow', schemaMarkupJson ? JSON.stringify(schemaMarkupJson) : null, JSON.stringify(citationsArray), JSON.stringify(contentLabelsJson), text_article || null]
+      `INSERT INTO articles (title, slug, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, author_id, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels, text_article, audio_files)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36)`,
+      [title, slug, content, excerpt, category, tagsArray, seo_title, seo_description, keywordsArray, status || 'draft', featured_image, published_url, article_code, isFeatured, req.user.id, publishedAtValue, updatedAtValue, timeToRead, JSON.stringify(articleImagesArray), og_title, og_description, og_image, og_type || 'article', twitter_card || 'summary_large_image', twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta || 'index, follow', schemaMarkupJson ? JSON.stringify(schemaMarkupJson) : null, JSON.stringify(citationsArray), JSON.stringify(contentLabelsJson), text_article || null, JSON.stringify(audioFilesJson)]
     );
 
     req.session.successMessage = 'Article created successfully';
@@ -255,7 +259,7 @@ router.get('/articles/:id/edit', async (req, res) => {
 // Update article
 router.post('/articles/:id', async (req, res) => {
   try {
-    const { title, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels, text_article } = req.body;
+    const { title, content, excerpt, category, tags, seo_title, seo_description, seo_keywords, status, featured_image, published_url, article_code, featured, published_at, updated_at, time_to_read, article_images, og_title, og_description, og_image, og_type, twitter_card, twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta, schema_markup, citations, content_labels, text_article, audio_files } = req.body;
 
     // Validate required fields
     if (!title || !title.trim()) {
@@ -286,6 +290,10 @@ router.post('/articles/:id', async (req, res) => {
     if (content_labels && content_labels.trim()) {
       try { contentLabelsJson = JSON.parse(content_labels); } catch(e) { contentLabelsJson = {}; }
     }
+    let audioFilesJson = {};
+    if (audio_files && audio_files.trim()) {
+      try { audioFilesJson = JSON.parse(audio_files); } catch(e) { audioFilesJson = {}; }
+    }
 
     const result = await db.query(
       `UPDATE articles
@@ -301,9 +309,10 @@ router.post('/articles/:id', async (req, res) => {
            twitter_card = $23, twitter_title = $24, twitter_description = $25,
            twitter_image = $26, twitter_site = $27, twitter_creator = $28,
            canonical_url = $29, robots_meta = $30, schema_markup = $31,
-           citations = $32::jsonb, content_labels = $33::jsonb, text_article = $34
+           citations = $32::jsonb, content_labels = $33::jsonb, text_article = $34,
+           audio_files = $35::jsonb
        WHERE id = $18 RETURNING id`,
-      [title, content, excerpt, category, tagsArray, seo_title, seo_description, keywordsArray, status, featured_image, published_url, isFeatured, updatedAtValue, publishedAtValue, timeToRead, article_code, JSON.stringify(articleImagesArray), req.params.id, og_title, og_description, og_image, og_type || 'article', twitter_card || 'summary_large_image', twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta || 'index, follow', schemaMarkupJson ? JSON.stringify(schemaMarkupJson) : null, JSON.stringify(citationsArray), JSON.stringify(contentLabelsJson), text_article || null]
+      [title, content, excerpt, category, tagsArray, seo_title, seo_description, keywordsArray, status, featured_image, published_url, isFeatured, updatedAtValue, publishedAtValue, timeToRead, article_code, JSON.stringify(articleImagesArray), req.params.id, og_title, og_description, og_image, og_type || 'article', twitter_card || 'summary_large_image', twitter_title, twitter_description, twitter_image, twitter_site, twitter_creator, canonical_url, robots_meta || 'index, follow', schemaMarkupJson ? JSON.stringify(schemaMarkupJson) : null, JSON.stringify(citationsArray), JSON.stringify(contentLabelsJson), text_article || null, JSON.stringify(audioFilesJson)]
     );
 
     if (result.rowCount === 0) {

--- a/wts-admin/src/views/content/articles/form.ejs
+++ b/wts-admin/src/views/content/articles/form.ejs
@@ -523,6 +523,47 @@
 
           <!-- ===== TAB: ADVANCED ===== -->
           <div class="form-tab-panel" id="panel-advanced" style="display:none;">
+
+          <!-- Article Audio Section -->
+          <div class="form-section">
+            <h3 class="form-section-title"><i class="fas fa-headphones"></i> Article Audio (Listen to this Article)</h3>
+            <p class="form-help" style="margin-bottom: 12px;">Enable multi-language audio playback. The audio widget appears beneath the article title on the published page.</p>
+
+            <input type="hidden" id="audio_files" name="audio_files" value="<%= article && article.audio_files ? (typeof article.audio_files === 'string' ? article.audio_files : JSON.stringify(article.audio_files)) : '{}' %>">
+
+            <div class="form-group" style="margin-bottom: 16px;">
+              <label class="form-label" style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
+                <input type="checkbox" id="audioEnabledToggle" style="width: 18px; height: 18px; cursor: pointer;">
+                <span>Enable audio widget for this article</span>
+              </label>
+            </div>
+
+            <div id="audioFieldsPanel" style="display: none;">
+              <div id="audioLangRows"></div>
+
+              <div style="display: flex; gap: 8px; align-items: center; margin-top: 12px;">
+                <select id="audioNewLangSelect" class="form-input" style="max-width: 180px; font-size: 13px;">
+                  <option value="">Add language...</option>
+                  <option value="en">English</option>
+                  <option value="lo">Lao</option>
+                  <option value="th">Thai</option>
+                  <option value="es">Spanish</option>
+                  <option value="fr">French</option>
+                  <option value="zh">Chinese</option>
+                  <option value="ja">Japanese</option>
+                  <option value="ko">Korean</option>
+                  <option value="vi">Vietnamese</option>
+                  <option value="km">Khmer</option>
+                  <option value="my">Burmese</option>
+                </select>
+                <button type="button" id="addAudioLangBtn" class="btn btn-secondary btn-sm">
+                  <i class="fas fa-plus"></i> Add
+                </button>
+              </div>
+              <p class="form-help" style="margin-top: 4px;">Paste the direct URL to each language's MP3/WAV audio file.</p>
+            </div>
+          </div>
+
           <!-- Citations / Sources Section -->
           <div class="form-section">
             <h3 class="form-section-title"><i class="fas fa-quote-right"></i> Citations &amp; Sources</h3>
@@ -4103,6 +4144,116 @@ document.addEventListener('DOMContentLoaded', function() {
   bind('testGhConnectionBtn', function() { testGhConnection(); });
   bind('publishToGithubBtn', function() { publishToGitHub(); });
 });
+
+// ==================== ARTICLE AUDIO MANAGEMENT ====================
+(function() {
+  var LANG_LABELS = {
+    en: 'English', lo: 'Lao', th: 'Thai', es: 'Spanish',
+    fr: 'French', zh: 'Chinese', ja: 'Japanese', ko: 'Korean',
+    vi: 'Vietnamese', km: 'Khmer', my: 'Burmese'
+  };
+
+  var hiddenInput   = document.getElementById('audio_files');
+  var toggle        = document.getElementById('audioEnabledToggle');
+  var panel         = document.getElementById('audioFieldsPanel');
+  var rowsContainer = document.getElementById('audioLangRows');
+  var addBtn        = document.getElementById('addAudioLangBtn');
+  var langSelect    = document.getElementById('audioNewLangSelect');
+
+  if (!hiddenInput || !toggle) return;
+
+  // Parse stored value
+  var audioData = {};
+  try { audioData = JSON.parse(hiddenInput.value) || {}; } catch(e) { audioData = {}; }
+
+  // Check if audio is enabled (has at least one key or _enabled flag)
+  var isEnabled = audioData._enabled === true || Object.keys(audioData).filter(function(k){ return k !== '_enabled'; }).length > 0;
+  toggle.checked = isEnabled;
+  panel.style.display = isEnabled ? 'block' : 'none';
+
+  toggle.addEventListener('change', function() {
+    panel.style.display = toggle.checked ? 'block' : 'none';
+    syncHiddenInput();
+  });
+
+  function createRow(langCode, url) {
+    var row = document.createElement('div');
+    row.style.cssText = 'display:flex; align-items:center; gap:8px; margin-bottom:8px;';
+    row.dataset.lang = langCode;
+
+    var label = document.createElement('span');
+    label.style.cssText = 'min-width:80px; font-weight:600; font-size:13px; color:#555;';
+    label.textContent = LANG_LABELS[langCode] || langCode;
+
+    var input = document.createElement('input');
+    input.type = 'url';
+    input.className = 'form-input';
+    input.placeholder = 'https://cdn.example.com/audio/article-' + langCode + '.mp3';
+    input.value = url || '';
+    input.style.cssText = 'flex:1; font-size:13px;';
+    input.addEventListener('input', syncHiddenInput);
+
+    var removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'btn btn-sm';
+    removeBtn.style.cssText = 'background:none; border:none; color:#dc3545; font-size:18px; cursor:pointer; padding:4px 8px;';
+    removeBtn.innerHTML = '&times;';
+    removeBtn.title = 'Remove ' + (LANG_LABELS[langCode] || langCode);
+    removeBtn.addEventListener('click', function() {
+      row.remove();
+      syncHiddenInput();
+      updateSelectOptions();
+    });
+
+    row.appendChild(label);
+    row.appendChild(input);
+    row.appendChild(removeBtn);
+    rowsContainer.appendChild(row);
+  }
+
+  function syncHiddenInput() {
+    var data = {};
+    if (toggle.checked) {
+      data._enabled = true;
+      var rows = rowsContainer.querySelectorAll('[data-lang]');
+      rows.forEach(function(row) {
+        var code = row.dataset.lang;
+        var val = row.querySelector('input[type="url"]').value.trim();
+        if (val) data[code] = val;
+      });
+    }
+    hiddenInput.value = JSON.stringify(data);
+    // Trigger unsaved badge
+    var badge = document.getElementById('unsavedBadge');
+    if (badge) badge.style.display = 'inline-flex';
+  }
+
+  function updateSelectOptions() {
+    var existing = [];
+    rowsContainer.querySelectorAll('[data-lang]').forEach(function(r) { existing.push(r.dataset.lang); });
+    var options = langSelect.querySelectorAll('option');
+    options.forEach(function(opt) {
+      if (opt.value) opt.disabled = existing.indexOf(opt.value) !== -1;
+    });
+    langSelect.value = '';
+  }
+
+  // Initialize rows from stored data
+  Object.keys(audioData).forEach(function(key) {
+    if (key === '_enabled') return;
+    createRow(key, audioData[key]);
+  });
+  updateSelectOptions();
+
+  // Add language button
+  addBtn.addEventListener('click', function() {
+    var code = langSelect.value;
+    if (!code) return;
+    createRow(code, '');
+    syncHiddenInput();
+    updateSelectOptions();
+  });
+})();
 </script>
 
 <%- include('../../partials/footer') %>


### PR DESCRIPTION
- Add standalone audio widget component (js/components/article-audio-widget.html) with play/pause, scrubber, language switcher, JSON-LD AudioObject schema, semantic <figure>/<figcaption> markup, and GA4 analytics hooks
- Add audio management UI to wts-admin article form (Advanced tab) with enable/disable toggle and dynamic per-language URL inputs
- Add audio_files JSONB column migration to both wts-admin and blog-backend DBs
- Update wts-admin content routes (POST/PUT) to persist audio_files
- Update blog-backend POST/PUT routes to handle audio_files
- Integrate audio widget into generate-seo-articles.js static HTML generator
- Add audio controls to legacy admin/blog-admin.html form

https://claude.ai/code/session_01LBGwSbVeVUCB3ayAu9exdD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can enable and manage multilingual audio per article (add/remove languages, set URLs, toggle per-article).
  * Articles now persist per-language audio so settings are saved with the article.
  * Readers see an embedded article audio player with language selector, play/pause, time display, progress scrubber, and responsive/accessible controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->