### PR TITLE
fix: complete responsive coverage for remaining non-responsive templates

### DIFF
--- a/wts-admin/public/css/style.css
+++ b/wts-admin/public/css/style.css
@@ -3345,3 +3345,353 @@ select.form-input {
     margin-bottom: 8px;
   }
 }
+
+/* ==========================================
+   RESPONSIVE GRID UTILITY CLASSES
+   ========================================== */
+
+/* 2-column grid that stacks on mobile */
+.responsive-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-lg);
+}
+
+/* 3-column grid that stacks on mobile */
+.responsive-grid-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: var(--space-md);
+}
+
+/* Card grid with auto-fill and safe min */
+.responsive-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(340px, 100%), 1fr));
+  gap: var(--space-md);
+}
+
+@media (max-width: 768px) {
+  .responsive-grid-2 {
+    grid-template-columns: 1fr;
+  }
+
+  .responsive-grid-3 {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Campaign / category legend row */
+.legend-row {
+  display: flex;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+  flex-wrap: wrap;
+  font-size: var(--text-sm);
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.legend-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+/* Alert / warning banner */
+.alert-banner {
+  border-radius: var(--radius);
+  padding: var(--space-md) var(--space-lg);
+  margin-bottom: var(--space-lg);
+  display: flex;
+  gap: var(--space-md);
+  align-items: flex-start;
+}
+
+.alert-banner-warning {
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+}
+
+.alert-banner-warning,
+.alert-banner-warning p,
+.alert-banner-warning i {
+  color: #856404;
+}
+
+@media (max-width: 480px) {
+  .alert-banner {
+    flex-direction: column;
+  }
+}
+
+/* Platform breakdown / stats bar items */
+.stat-bar-item {
+  margin-bottom: var(--space-md);
+}
+
+.stat-bar-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--text-sm);
+  margin-bottom: 4px;
+}
+
+.stat-bar-track {
+  background: var(--gray-100);
+  border-radius: 4px;
+  height: 8px;
+  overflow: hidden;
+}
+
+.stat-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+}
+
+/* Provider / key-value list */
+.kv-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--gray-100);
+  font-size: var(--text-sm);
+}
+
+/* Quick link cards grid */
+.quick-links-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(200px, 100%), 1fr));
+  gap: var(--space-md);
+}
+
+.quick-link-card {
+  text-decoration: none;
+  text-align: center;
+  padding: var(--space-lg);
+}
+
+.quick-link-card .quick-link-icon {
+  font-size: 24px;
+  margin-bottom: 8px;
+}
+
+.quick-link-card .quick-link-title {
+  font-weight: 600;
+  color: var(--gray-700);
+}
+
+.quick-link-card .quick-link-desc {
+  font-size: var(--text-xs);
+  color: var(--gray-400);
+}
+
+/* Empty state inline variant */
+.empty-state-inline {
+  padding: var(--space-xl);
+  text-align: center;
+  color: var(--gray-400);
+}
+
+.empty-state-inline i {
+  font-size: 32px;
+  color: var(--gray-300);
+  margin-bottom: 10px;
+  display: block;
+}
+
+/* ==========================================
+   PRODUCT PREVIEW PANEL RESPONSIVE
+   ========================================== */
+
+@media (max-width: 768px) {
+  #preview-panel {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+}
+
+/* ==========================================
+   FORM-CARD MAX-WIDTH RESPONSIVE
+   ========================================== */
+
+@media (max-width: 768px) {
+  .form-card {
+    max-width: 100% !important;
+  }
+}
+
+/* ==========================================
+   MODAL INLINE MAX-WIDTH OVERRIDE
+   ========================================== */
+
+@media (max-width: 480px) {
+  .modal-card[style*="max-width"] {
+    max-width: calc(100vw - 16px) !important;
+  }
+}
+
+/* ==========================================
+   SEO-TERMS TOOLTIP TD RESPONSIVE
+   ========================================== */
+
+@media (max-width: 768px) {
+  .table-responsive-cards td[data-label="Tooltip"] {
+    max-width: none !important;
+    white-space: normal !important;
+    overflow: visible !important;
+  }
+}
+
+/* ==========================================
+   COPY TOAST MOBILE POSITION
+   ========================================== */
+
+@media (max-width: 480px) {
+  .copy-toast {
+    right: 50%;
+    transform: translateX(50%);
+    bottom: 16px;
+    left: auto;
+  }
+}
+
+/* ==========================================
+   FORM ACTIONS BUTTONS NO-WRAP
+   ========================================== */
+
+@media (max-width: 768px) {
+  .form-actions .btn {
+    white-space: nowrap;
+    min-width: 0;
+  }
+}
+
+/* ==========================================
+   DASHBOARD COMPACT TABLES RESPONSIVE
+   ========================================== */
+
+@media (max-width: 768px) {
+  .dashboard-cards-grid .table td {
+    font-size: var(--text-sm);
+  }
+
+  .dashboard-cards-grid .table a {
+    word-break: break-word;
+  }
+}
+
+/* ==========================================
+   IMAGE DETAIL / MICROSITE DETAIL 2-COL
+   ========================================== */
+
+@media (max-width: 768px) {
+  /* All direct child 2-col grids in page-content stack */
+  .page-content > .responsive-grid-2,
+  .responsive-grid-2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ==========================================
+   CALENDAR UPCOMING POSTS TABLE RESPONSIVE
+   ========================================== */
+
+@media (max-width: 768px) {
+  .table-responsive-cards td[data-label="Content"] {
+    max-width: none !important;
+  }
+
+  .table-responsive-cards td[data-label="Content"] a {
+    white-space: normal !important;
+    overflow: visible !important;
+  }
+}
+
+/* ==========================================
+   DOMAIN FORM RESPONSIVE
+   ========================================== */
+
+.domain-add-form {
+  display: flex;
+  gap: var(--space-md);
+  align-items: flex-end;
+}
+
+.domain-add-form .form-group {
+  margin-bottom: 0;
+}
+
+.domain-add-form .form-group:first-child {
+  flex: 1;
+}
+
+@media (max-width: 640px) {
+  .domain-add-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .domain-add-form .form-group {
+    width: 100% !important;
+  }
+}
+
+/* ==========================================
+   DEPLOYMENT FORM RESPONSIVE
+   ========================================== */
+
+.deploy-form {
+  display: flex;
+  gap: var(--space-md);
+  align-items: flex-end;
+}
+
+.deploy-form .form-group {
+  flex: 1;
+  margin-bottom: 0;
+}
+
+@media (max-width: 640px) {
+  .deploy-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+/* ==========================================
+   DETAIL ROW (EXPANDABLE) RESPONSIVE
+   ========================================== */
+
+@media (max-width: 768px) {
+  .detail-row td {
+    grid-column: 1 / -1;
+  }
+
+  .detail-row .responsive-grid-2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ==========================================
+   DELETE CARD RESPONSIVE
+   ========================================== */
+
+@media (max-width: 480px) {
+  .delete-card-body {
+    flex-direction: column;
+    gap: var(--space-md);
+    align-items: flex-start !important;
+  }
+}
+
+.delete-card-body {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/wts-admin/public/js/main.js
+++ b/wts-admin/public/js/main.js
@@ -1,5 +1,22 @@
 // WTS Admin - Main JavaScript
 
+// Body scroll lock helpers (iOS-safe)
+let _scrollY = 0;
+function lockBody() {
+  _scrollY = window.scrollY;
+  document.body.style.position = 'fixed';
+  document.body.style.top = `-${_scrollY}px`;
+  document.body.style.width = '100%';
+  document.body.style.overflow = 'hidden';
+}
+function unlockBody() {
+  document.body.style.position = '';
+  document.body.style.top = '';
+  document.body.style.width = '';
+  document.body.style.overflow = '';
+  window.scrollTo(0, _scrollY);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initSidebar();
   initDropdowns();
@@ -26,7 +43,7 @@ function initSidebar() {
     mobileMenuBtn.addEventListener('click', () => {
       sidebar.classList.add('open');
       overlay.classList.add('active');
-      document.body.style.overflow = 'hidden';
+      lockBody();
     });
   }
 
@@ -41,7 +58,7 @@ function initSidebar() {
   function closeSidebar() {
     sidebar.classList.remove('open');
     overlay.classList.remove('active');
-    document.body.style.overflow = '';
+    unlockBody();
   }
 
   // Close sidebar on escape key
@@ -479,13 +496,13 @@ function initMobileSearch() {
 
   openBtn.addEventListener('click', () => {
     overlay.classList.add('active');
-    document.body.style.overflow = 'hidden';
+    lockBody();
     setTimeout(() => searchInput?.focus(), 100);
   });
 
   function closeOverlay() {
     overlay.classList.remove('active');
-    document.body.style.overflow = '';
+    unlockBody();
   }
 
   if (closeBtn) closeBtn.addEventListener('click', closeOverlay);
@@ -556,7 +573,7 @@ function initKeyboardShortcuts() {
       const mobileOverlay = document.getElementById('mobileSearchOverlay');
       if (mobileOverlay?.classList.contains('active')) {
         mobileOverlay.classList.remove('active');
-        document.body.style.overflow = '';
+        unlockBody();
         return;
       }
       // Close any open modals

--- a/wts-admin/src/views/business/automations/list.ejs
+++ b/wts-admin/src/views/business/automations/list.ejs
@@ -19,7 +19,7 @@
       <div class="card-body" style="padding: 0;">
         <% if (automations.length > 0) { %>
         <div class="table-container">
-          <table class="table">
+          <table class="table table-responsive-cards">
             <thead>
               <tr>
                 <th>Name</th>
@@ -32,11 +32,11 @@
             <tbody>
               <% automations.forEach(auto => { %>
               <tr>
-                <td><strong><%= auto.name %></strong></td>
-                <td><%= auto.trigger_type || '-' %></td>
-                <td><%= auto.action_type || '-' %></td>
-                <td><span class="status-badge <%= auto.status %>"><%= auto.status %></span></td>
-                <td>
+                <td data-label="Name"><strong><%= auto.name %></strong></td>
+                <td data-label="Trigger"><%= auto.trigger_type || '-' %></td>
+                <td data-label="Action"><%= auto.action_type || '-' %></td>
+                <td data-label="Status"><span class="status-badge <%= auto.status %>"><%= auto.status %></span></td>
+                <td data-label="Actions">
                   <div class="table-actions">
                     <a href="/business/automations/<%= auto.id %>/edit" class="btn btn-sm btn-secondary"><i class="fas fa-edit"></i></a>
                     <form action="/business/automations/<%= auto.id %>/delete" method="POST" style="display: inline;">

--- a/wts-admin/src/views/dashboard/index.ejs
+++ b/wts-admin/src/views/dashboard/index.ejs
@@ -164,8 +164,8 @@
             </tbody>
           </table>
           <% } else { %>
-          <div class="empty-state" style="padding: 40px;">
-            <i class="fas fa-newspaper" style="font-size: 32px; color: var(--gray-300); margin-bottom: 10px;"></i>
+          <div class="empty-state-inline">
+            <i class="fas fa-newspaper"></i>
             <p>No articles yet</p>
           </div>
           <% } %>
@@ -197,8 +197,8 @@
             </tbody>
           </table>
           <% } else { %>
-          <div class="empty-state" style="padding: 40px;">
-            <i class="fas fa-globe" style="font-size: 32px; color: var(--gray-300); margin-bottom: 10px;"></i>
+          <div class="empty-state-inline">
+            <i class="fas fa-globe"></i>
             <p>No microsites yet</p>
             <a href="/webdev/microsites/new" class="btn btn-sm btn-primary" style="margin-top: 8px;">Create one</a>
           </div>
@@ -250,7 +250,7 @@
         <a href="/social/calendar" class="btn btn-sm btn-secondary">View Calendar</a>
       </div>
       <div class="card-body" style="padding: 0;">
-        <table class="table">
+        <table class="table table-responsive-cards">
           <thead>
             <tr>
               <th>Content</th>
@@ -261,17 +261,17 @@
           <tbody>
             <% scheduledPosts.forEach(post => { %>
             <tr>
-              <td>
+              <td data-label="Content">
                 <a href="/social/posts/<%= post.id %>/edit"><%= post.content ? post.content.substring(0, 60) + (post.content.length > 60 ? '...' : '') : 'Untitled' %></a>
               </td>
-              <td>
+              <td data-label="Platforms">
                 <% if (post.platforms && post.platforms.length) { %>
                 <% post.platforms.forEach(p => { %>
                 <span class="status-badge" style="font-size: 11px;"><%= p %></span>
                 <% }); %>
                 <% } %>
               </td>
-              <td style="white-space: nowrap;"><%= new Date(post.scheduled_at).toLocaleString() %></td>
+              <td data-label="Scheduled For"><%= new Date(post.scheduled_at).toLocaleString() %></td>
             </tr>
             <% }); %>
           </tbody>

--- a/wts-admin/src/views/images/detail.ejs
+++ b/wts-admin/src/views/images/detail.ejs
@@ -26,7 +26,7 @@
       </div>
     </div>
 
-    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 24px;">
+    <div class="responsive-grid-2">
       <!-- Left: Image Preview & Info -->
       <div>
         <div class="card">
@@ -242,7 +242,7 @@
 
         <!-- Delete -->
         <div class="card" style="margin-top: 20px; border: 1px solid var(--danger);">
-          <div class="card-body" style="display: flex; justify-content: space-between; align-items: center;">
+          <div class="card-body delete-card-body">
             <div>
               <p style="font-weight: 600; color: var(--danger);">Archive this image</p>
               <p class="form-help">Removes from library. The file remains on disk.</p>

--- a/wts-admin/src/views/images/library.ejs
+++ b/wts-admin/src/views/images/library.ejs
@@ -177,7 +177,7 @@
           <% } else { %>
           <!-- List View -->
           <div class="table-container">
-            <table class="table">
+            <table class="table table-responsive-cards">
               <thead>
                 <tr>
                   <th style="width: 36px;"><input type="checkbox" id="selectAllListCheckbox" onchange="toggleSelectAll(this.checked); updateBulkBar();" title="Select all"></th>
@@ -193,21 +193,21 @@
               <tbody>
                 <% images.forEach(image => { %>
                 <tr data-image-id="<%= image.id %>">
-                  <td><input type="checkbox" class="image-checkbox" value="<%= image.id %>" onchange="updateBulkBar()"></td>
-                  <td>
+                  <td data-label="Select"><input type="checkbox" class="image-checkbox" value="<%= image.id %>" onchange="updateBulkBar()"></td>
+                  <td data-label="Preview">
                     <div class="image-table-thumb">
                       <img src="<%= image.cdn_url || ('/images-serve/' + encodeURIComponent(image.filename) + '?path=' + encodeURIComponent(image.file_path)) %>" alt="<%= image.alt_text || image.filename %>" loading="lazy">
                     </div>
                   </td>
-                  <td>
+                  <td data-label="Filename">
                     <strong><a href="/images/<%= image.id %>"><%= image.filename %></a></strong>
                     <br>
                     <small style="color: var(--gray-500);"><%= image.mime_type %></small>
                   </td>
-                  <td><span class="status-badge <%= image.category %>"><%= image.category %></span></td>
-                  <td><%= image.file_size_formatted %></td>
-                  <td><%= image.width && image.height ? image.width + ' x ' + image.height : '-' %></td>
-                  <td>
+                  <td data-label="Category"><span class="status-badge <%= image.category %>"><%= image.category %></span></td>
+                  <td data-label="Size"><%= image.file_size_formatted %></td>
+                  <td data-label="Dimensions"><%= image.width && image.height ? image.width + ' x ' + image.height : '-' %></td>
+                  <td data-label="SEO">
                     <% if (image.alt_text) { %>
                     <span style="color: var(--success);" title="Alt text set"><i class="fas fa-check-circle"></i></span>
                     <% } else { %>
@@ -217,7 +217,7 @@
                     <span style="color: var(--success);" title="Title set"><i class="fas fa-heading"></i></span>
                     <% } %>
                   </td>
-                  <td>
+                  <td data-label="Actions">
                     <div class="table-actions">
                       <button class="btn btn-sm btn-secondary copy-cdn-url" data-url="<%= image.cdn_url %>" title="Copy CDN URL">
                         <i class="fas fa-link"></i>

--- a/wts-admin/src/views/images/upload-multiple.ejs
+++ b/wts-admin/src/views/images/upload-multiple.ejs
@@ -18,16 +18,16 @@
     </div>
 
     <% if (!githubConfigured) { %>
-    <div style="background: #fff3cd; border: 1px solid #ffc107; border-radius: var(--radius); padding: 16px 20px; margin-bottom: 20px; max-width: 900px; display: flex; gap: 12px; align-items: flex-start;">
-      <i class="fas fa-exclamation-triangle" style="color: #856404; font-size: 18px; margin-top: 2px;"></i>
+    <div class="alert-banner alert-banner-warning">
+      <i class="fas fa-exclamation-triangle" style="font-size: 18px; margin-top: 2px;"></i>
       <div>
-        <p style="font-weight: 600; color: #856404; margin-bottom: 4px;">GitHub Token Not Configured</p>
-        <p style="font-size: 13px; color: #856404;">Uploaded images will be stored locally only and <strong>will not appear on the CDN</strong>. Add <code>GITHUB_TOKEN</code> to enable CDN publishing.</p>
+        <p style="font-weight: 600; margin-bottom: 4px;">GitHub Token Not Configured</p>
+        <p style="font-size: 13px;">Uploaded images will be stored locally only and <strong>will not appear on the CDN</strong>. Add <code>GITHUB_TOKEN</code> to enable CDN publishing.</p>
       </div>
     </div>
     <% } %>
 
-    <div class="card form-card" style="max-width: 900px;">
+    <div class="card form-card">
       <div class="card-body">
         <form action="/images/upload-multiple" method="POST" enctype="multipart/form-data" id="multiUploadForm">
 

--- a/wts-admin/src/views/images/upload.ejs
+++ b/wts-admin/src/views/images/upload.ejs
@@ -18,16 +18,16 @@
     </div>
 
     <% if (!githubConfigured) { %>
-    <div style="background: #fff3cd; border: 1px solid #ffc107; border-radius: var(--radius); padding: 16px 20px; margin-bottom: 20px; max-width: 900px; display: flex; gap: 12px; align-items: flex-start;">
-      <i class="fas fa-exclamation-triangle" style="color: #856404; font-size: 18px; margin-top: 2px;"></i>
+    <div class="alert-banner alert-banner-warning">
+      <i class="fas fa-exclamation-triangle" style="font-size: 18px; margin-top: 2px;"></i>
       <div>
-        <p style="font-weight: 600; color: #856404; margin-bottom: 4px;">GitHub Token Not Configured</p>
-        <p style="font-size: 13px; color: #856404;">Uploaded images will be stored locally only and <strong>will not appear on the CDN</strong>. They will be lost when Railway redeploys. Add <code>GITHUB_TOKEN</code> to your Railway environment variables to enable automatic CDN publishing.</p>
+        <p style="font-weight: 600; margin-bottom: 4px;">GitHub Token Not Configured</p>
+        <p style="font-size: 13px;">Uploaded images will be stored locally only and <strong>will not appear on the CDN</strong>. They will be lost when Railway redeploys. Add <code>GITHUB_TOKEN</code> to your Railway environment variables to enable automatic CDN publishing.</p>
       </div>
     </div>
     <% } %>
 
-    <div class="card form-card" style="max-width: 900px;">
+    <div class="card form-card">
       <div class="card-body">
         <form action="/images/upload" method="POST" enctype="multipart/form-data" id="uploadForm">
 

--- a/wts-admin/src/views/social/analytics-dashboard.ejs
+++ b/wts-admin/src/views/social/analytics-dashboard.ejs
@@ -51,7 +51,7 @@
         </div>
       </div>
 
-      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 24px;">
+      <div class="responsive-grid-2" style="margin-bottom: 24px;">
         <!-- Platform Breakdown -->
         <div class="card">
           <div class="card-header"><h3><i class="fas fa-chart-pie"></i> Platform Breakdown</h3></div>
@@ -61,18 +61,18 @@
               const colors = { 'Facebook': '#1877f2', 'Twitter/X': '#000', 'Instagram': '#e4405f', 'LinkedIn': '#0a66c2', 'TikTok': '#000', 'Pinterest': '#e60023', 'YouTube': '#ff0000' };
               const maxCount = Math.max(...platformStats.map(x => parseInt(x.count)));
             %>
-            <div style="margin-bottom: 12px;">
-              <div style="display: flex; justify-content: space-between; font-size: 13px; margin-bottom: 4px;">
+            <div class="stat-bar-item">
+              <div class="stat-bar-header">
                 <span><strong><%= p.platform %></strong></span>
                 <span><%= p.count %> posts / <%= p.clicks || 0 %> clicks</span>
               </div>
-              <div style="background: var(--gray-100); border-radius: 4px; height: 8px; overflow: hidden;">
-                <div style="background: <%= colors[p.platform] || 'var(--primary)' %>; height: 100%; width: <%= (parseInt(p.count) / maxCount * 100) %>%; border-radius: 4px;"></div>
+              <div class="stat-bar-track">
+                <div class="stat-bar-fill" style="background: <%= colors[p.platform] || 'var(--primary)' %>; width: <%= (parseInt(p.count) / maxCount * 100) %>%;"></div>
               </div>
             </div>
             <% }); %>
             <% } else { %>
-            <p style="color: var(--gray-400); text-align: center; padding: 24px;">No published posts yet</p>
+            <div class="empty-state-inline">No published posts yet</div>
             <% } %>
           </div>
         </div>
@@ -83,16 +83,16 @@
           <div class="card-body">
             <% if (aiCost.length > 0) { %>
             <% aiCost.forEach(function(a) { %>
-            <div style="display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid var(--gray-100);">
-              <span style="font-size: 14px;"><code><%= a.ai_provider %></code></span>
-              <span style="font-size: 14px; font-weight: 600;"><%= a.uses %> posts</span>
+            <div class="kv-row">
+              <span><code><%= a.ai_provider %></code></span>
+              <span style="font-weight: 600;"><%= a.uses %> posts</span>
             </div>
             <% }); %>
             <div style="margin-top: 12px; text-align: right;">
               <button class="btn btn-sm btn-secondary" onclick="loadCosts()"><i class="fas fa-dollar-sign"></i> View Costs</button>
             </div>
             <% } else { %>
-            <p style="color: var(--gray-400); text-align: center; padding: 24px;">No AI-generated posts yet</p>
+            <div class="empty-state-inline">No AI-generated posts yet</div>
             <% } %>
           </div>
         </div>
@@ -104,15 +104,15 @@
         <div class="card-header"><h3><i class="fas fa-bullhorn"></i> Campaign Performance</h3></div>
         <div class="card-body" style="padding: 0;">
           <div class="table-container">
-            <table class="table">
+            <table class="table table-responsive-cards">
               <thead><tr><th>Campaign</th><th>Posts</th><th>Clicks</th><th>CTR</th></tr></thead>
               <tbody>
                 <% campaignStats.forEach(function(c) { %>
                 <tr>
-                  <td><span style="display: inline-block; width: 10px; height: 10px; border-radius: 50%; background: <%= c.color || 'var(--primary)' %>; margin-right: 8px;"></span><%= c.name %></td>
-                  <td><%= c.posts %></td>
-                  <td><%= c.clicks || 0 %></td>
-                  <td><%= parseInt(c.posts) > 0 ? ((parseInt(c.clicks || 0) / parseInt(c.posts)) * 100).toFixed(1) + '%' : '-' %></td>
+                  <td data-label="Campaign"><span style="display: inline-block; width: 10px; height: 10px; border-radius: 50%; background: <%= c.color || 'var(--primary)' %>; margin-right: 8px;"></span><%= c.name %></td>
+                  <td data-label="Posts"><%= c.posts %></td>
+                  <td data-label="Clicks"><%= c.clicks || 0 %></td>
+                  <td data-label="CTR"><%= parseInt(c.posts) > 0 ? ((parseInt(c.clicks || 0) / parseInt(c.posts)) * 100).toFixed(1) + '%' : '-' %></td>
                 </tr>
                 <% }); %>
               </tbody>
@@ -128,18 +128,18 @@
         <div class="card-body" style="padding: 0;">
           <% if (topPosts.length > 0) { %>
           <div class="table-container">
-            <table class="table">
-              <thead><tr><th style="width: 50%;">Content</th><th>Platform</th><th>Source</th><th>Clicks</th><th>Link</th></tr></thead>
+            <table class="table table-responsive-cards">
+              <thead><tr><th>Content</th><th>Platform</th><th>Source</th><th>Clicks</th><th>Link</th></tr></thead>
               <tbody>
                 <% topPosts.forEach(function(post) { %>
                 <tr>
-                  <td style="font-size: 13px; max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"><%= (post.content || '').substring(0, 80) %></td>
-                  <td><%= (post.platforms || []).join(', ') %></td>
-                  <td><span class="source-badge source-badge-<%= post.source_type || 'standalone' %>" style="font-size: 10px; padding: 2px 6px;"><%= post.source_type || 'standalone' %></span></td>
-                  <td style="font-weight: 700;"><%= post.bitly_clicks || 0 %></td>
-                  <td>
+                  <td data-label="Content" style="font-size: 13px;"><%= (post.content || '').substring(0, 80) %></td>
+                  <td data-label="Platform"><%= (post.platforms || []).join(', ') %></td>
+                  <td data-label="Source"><span class="source-badge source-badge-<%= post.source_type || 'standalone' %>" style="font-size: 10px; padding: 2px 6px;"><%= post.source_type || 'standalone' %></span></td>
+                  <td data-label="Clicks" style="font-weight: 700;"><%= post.bitly_clicks || 0 %></td>
+                  <td data-label="Link">
                     <% if (post.bitly_url) { %>
-                    <a href="<%= post.bitly_url %>" target="_blank" style="font-size: 12px;"><%= post.bitly_url %></a>
+                    <a href="<%= post.bitly_url %>" target="_blank" style="font-size: 12px; word-break: break-all;"><%= post.bitly_url %></a>
                     <% } else { %>-<% } %>
                   </td>
                 </tr>
@@ -148,7 +148,7 @@
             </table>
           </div>
           <% } else { %>
-          <div style="text-align: center; padding: 32px; color: var(--gray-400);">No published posts yet</div>
+          <div class="empty-state-inline">No published posts yet</div>
           <% } %>
         </div>
       </div>

--- a/wts-admin/src/views/social/analytics.ejs
+++ b/wts-admin/src/views/social/analytics.ejs
@@ -55,7 +55,7 @@
         <div class="card-body">
           <% if (contentStats.length > 0) { %>
           <div class="table-container">
-            <table class="table">
+            <table class="table table-responsive-cards">
               <thead>
                 <tr>
                   <th>Content Type</th>
@@ -66,9 +66,9 @@
               <tbody>
                 <% contentStats.forEach(function(s) { %>
                 <tr>
-                  <td><span class="source-badge source-badge-<%= s.source_type || 'standalone' %>"><%= s.source_type || 'Standalone' %></span></td>
-                  <td><%= s.count %></td>
-                  <td><%= s.clicks || 0 %></td>
+                  <td data-label="Content Type"><span class="source-badge source-badge-<%= s.source_type || 'standalone' %>"><%= s.source_type || 'Standalone' %></span></td>
+                  <td data-label="Posts"><%= s.count %></td>
+                  <td data-label="Clicks"><%= s.clicks || 0 %></td>
                 </tr>
                 <% }); %>
               </tbody>
@@ -86,26 +86,26 @@
       </div>
 
       <!-- Quick Links -->
-      <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px;">
-        <a href="/social/analytics/dashboard" class="card" style="text-decoration: none; text-align: center; padding: 20px;">
-          <i class="fas fa-chart-line" style="font-size: 24px; color: var(--primary); margin-bottom: 8px;"></i>
-          <div style="font-weight: 600; color: var(--gray-700);">Full Dashboard</div>
-          <div style="font-size: 12px; color: var(--gray-400);">Platform stats, top posts, AI costs</div>
+      <div class="quick-links-grid">
+        <a href="/social/analytics/dashboard" class="card quick-link-card">
+          <div class="quick-link-icon" style="color: var(--primary);"><i class="fas fa-chart-line"></i></div>
+          <div class="quick-link-title">Full Dashboard</div>
+          <div class="quick-link-desc">Platform stats, top posts, AI costs</div>
         </a>
-        <a href="/social/retargeting" class="card" style="text-decoration: none; text-align: center; padding: 20px;">
-          <i class="fas fa-users" style="font-size: 24px; color: #8b5cf6; margin-bottom: 8px;"></i>
-          <div style="font-weight: 600; color: var(--gray-700);">Retargeting</div>
-          <div style="font-size: 12px; color: var(--gray-400);">Build custom audiences</div>
+        <a href="/social/retargeting" class="card quick-link-card">
+          <div class="quick-link-icon" style="color: #8b5cf6;"><i class="fas fa-users"></i></div>
+          <div class="quick-link-title">Retargeting</div>
+          <div class="quick-link-desc">Build custom audiences</div>
         </a>
-        <a href="/social/templates" class="card" style="text-decoration: none; text-align: center; padding: 20px;">
-          <i class="fas fa-copy" style="font-size: 24px; color: var(--success); margin-bottom: 8px;"></i>
-          <div style="font-weight: 600; color: var(--gray-700);">Templates</div>
-          <div style="font-size: 12px; color: var(--gray-400);">Reusable post templates</div>
+        <a href="/social/templates" class="card quick-link-card">
+          <div class="quick-link-icon" style="color: var(--success);"><i class="fas fa-copy"></i></div>
+          <div class="quick-link-title">Templates</div>
+          <div class="quick-link-desc">Reusable post templates</div>
         </a>
-        <a href="/social/ai-settings" class="card" style="text-decoration: none; text-align: center; padding: 20px;">
-          <i class="fas fa-robot" style="font-size: 24px; color: var(--warning); margin-bottom: 8px;"></i>
-          <div style="font-weight: 600; color: var(--gray-700);">AI Providers</div>
-          <div style="font-size: 12px; color: var(--gray-400);">Manage AI engines + costs</div>
+        <a href="/social/ai-settings" class="card quick-link-card">
+          <div class="quick-link-icon" style="color: var(--warning);"><i class="fas fa-robot"></i></div>
+          <div class="quick-link-title">AI Providers</div>
+          <div class="quick-link-desc">Manage AI engines + costs</div>
         </a>
       </div>
     </div>

--- a/wts-admin/src/views/social/calendar.ejs
+++ b/wts-admin/src/views/social/calendar.ejs
@@ -66,10 +66,10 @@
 
     <!-- Campaign Legend -->
     <% if (campaigns.length > 0) { %>
-    <div style="display: flex; gap: 16px; margin-bottom: 16px; flex-wrap: wrap; font-size: 13px;">
+    <div class="legend-row">
       <% campaigns.forEach(c => { %>
-      <div style="display: flex; align-items: center; gap: 6px;">
-        <span style="width: 12px; height: 12px; border-radius: 3px; background: <%= c.color || '#667eea' %>;"></span>
+      <div class="legend-item">
+        <span class="legend-dot" style="background: <%= c.color || '#667eea' %>;"></span>
         <span style="color: var(--gray-600);"><%= c.name %></span>
       </div>
       <% }); %>
@@ -146,7 +146,7 @@
       </div>
       <div class="card-body" style="padding: 0;">
         <div class="table-container">
-          <table class="table">
+          <table class="table table-responsive-cards">
             <thead>
               <tr>
                 <th>Date & Time</th>
@@ -159,26 +159,26 @@
             <tbody>
               <% upcoming.forEach(post => { %>
               <tr>
-                <td style="white-space: nowrap; font-size: 13px;">
+                <td data-label="Date & Time" style="font-size: 13px;">
                   <div><%= new Date(post.scheduled_at).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' }) %></div>
                   <div style="color: var(--gray-500);"><%= new Date(post.scheduled_at).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' }) %></div>
                 </td>
-                <td style="max-width: 250px;">
-                  <a href="/social/posts/<%= post.id %>/edit" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">
+                <td data-label="Content">
+                  <a href="/social/posts/<%= post.id %>/edit">
                     <%= post.content ? post.content.substring(0, 80) : '' %>
                   </a>
                 </td>
-                <td>
+                <td data-label="Campaign">
                   <% if (post.campaign_name) { %>
                   <span style="border-left: 3px solid <%= post.campaign_color || '#667eea' %>; padding-left: 8px; font-size: 13px;"><%= post.campaign_name %></span>
                   <% } else { %>-<% } %>
                 </td>
-                <td>
+                <td data-label="Platforms">
                   <% if (post.platforms) { post.platforms.forEach(p => { %>
                   <i class="<%= pIcons[p] || 'fas fa-globe' %>" style="margin-right: 3px;" title="<%= p %>"></i>
                   <% }); } %>
                 </td>
-                <td><span class="status-badge <%= post.status %>"><%= post.status %></span></td>
+                <td data-label="Status"><span class="status-badge <%= post.status %>"><%= post.status %></span></td>
               </tr>
               <% }); %>
             </tbody>

--- a/wts-admin/src/views/social/retargeting.ejs
+++ b/wts-admin/src/views/social/retargeting.ejs
@@ -22,7 +22,7 @@
         <div class="card-header"><h3><i class="fas fa-plus-circle"></i> New Audience</h3></div>
         <div class="card-body">
           <form action="/social/retargeting" method="POST">
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
+            <div class="responsive-grid-2">
               <div class="form-group">
                 <label class="form-label">Audience Name</label>
                 <input type="text" name="name" class="form-control" required placeholder="e.g. Blog Readers - Last 30 Days">
@@ -65,7 +65,7 @@
       <div class="card" style="margin-bottom: 24px;">
         <div class="card-header"><h3><i class="fas fa-info-circle"></i> Pixel Setup Guide</h3></div>
         <div class="card-body">
-          <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 24px;">
+          <div class="responsive-grid-2">
             <div>
               <h4 style="margin-bottom: 8px;"><i class="fab fa-facebook" style="color: #1877f2;"></i> Meta Pixel</h4>
               <ol style="font-size: 13px; color: var(--gray-600); padding-left: 20px;">
@@ -96,17 +96,17 @@
         <div class="card-body" style="padding: 0;">
           <% if (audiences.length > 0) { %>
           <div class="table-container">
-            <table class="table">
+            <table class="table table-responsive-cards">
               <thead><tr><th>Name</th><th>Platform</th><th>Source</th><th>Window</th><th>Status</th><th>Created</th></tr></thead>
               <tbody>
                 <% audiences.forEach(function(a) { %>
                 <tr>
-                  <td><strong><%= a.name %></strong><% if (a.description) { %><div style="font-size: 12px; color: var(--gray-400);"><%= a.description %></div><% } %></td>
-                  <td><%= a.platform %></td>
-                  <td><span class="source-badge source-badge-<%= a.source_type %>"><%= a.source_type %></span></td>
-                  <td><%= a.date_range_days %> days</td>
-                  <td><span class="status-badge <%= a.status %>"><%= a.status %></span></td>
-                  <td style="font-size: 13px; color: var(--gray-500);"><%= new Date(a.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) %></td>
+                  <td data-label="Name"><strong><%= a.name %></strong><% if (a.description) { %><div style="font-size: 12px; color: var(--gray-400);"><%= a.description %></div><% } %></td>
+                  <td data-label="Platform"><%= a.platform %></td>
+                  <td data-label="Source"><span class="source-badge source-badge-<%= a.source_type %>"><%= a.source_type %></span></td>
+                  <td data-label="Window"><%= a.date_range_days %> days</td>
+                  <td data-label="Status"><span class="status-badge <%= a.status %>"><%= a.status %></span></td>
+                  <td data-label="Created" style="font-size: 13px; color: var(--gray-500);"><%= new Date(a.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) %></td>
                 </tr>
                 <% }); %>
               </tbody>

--- a/wts-admin/src/views/social/templates.ejs
+++ b/wts-admin/src/views/social/templates.ejs
@@ -22,7 +22,7 @@
         <div class="card-header"><h3><i class="fas fa-plus-circle"></i> New Template</h3></div>
         <div class="card-body">
           <form action="/social/templates" method="POST">
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
+            <div class="responsive-grid-2">
               <div class="form-group">
                 <label class="form-label">Template Name</label>
                 <input type="text" name="name" class="form-control" required placeholder="e.g. Article Promotion - Twitter">
@@ -44,7 +44,7 @@
               <textarea name="content" class="form-control" rows="4" required placeholder="Use {title}, {url}, {excerpt} as placeholders..."></textarea>
               <div style="font-size: 11px; color: var(--gray-400); margin-top: 4px;">Variables: <code>{title}</code> <code>{url}</code> <code>{excerpt}</code> <code>{hashtags}</code></div>
             </div>
-            <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; margin-top: 12px;">
+            <div class="responsive-grid-3" style="margin-top: 12px;">
               <div class="form-group">
                 <label class="form-label">Tone</label>
                 <select name="tone" class="form-control">
@@ -90,7 +90,7 @@
         <div class="card-header"><h3><i class="fas fa-copy"></i> Saved Templates (<%= templates.length %>)</h3></div>
         <div class="card-body" style="padding: 0;">
           <% if (templates.length > 0) { %>
-          <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 16px; padding: 20px;">
+          <div class="responsive-card-grid" style="padding: 20px;">
             <% templates.forEach(function(t) { %>
             <div class="card" style="border: 1px solid var(--gray-200);">
               <div class="card-body" style="padding: 16px;">

--- a/wts-admin/src/views/webdev/microsites/detail.ejs
+++ b/wts-admin/src/views/webdev/microsites/detail.ejs
@@ -109,7 +109,7 @@
       </div>
     </div>
 
-    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 24px;">
+    <div class="responsive-grid-2">
       <div class="card">
         <div class="card-header">
           <h2 class="card-title">Site Details</h2>
@@ -153,8 +153,8 @@
               </tbody>
             </table>
             <% } else { %>
-            <div style="padding: 24px; text-align: center; color: var(--gray-400);">
-              <i class="fas fa-rocket" style="font-size: 24px; margin-bottom: 8px;"></i>
+            <div class="empty-state-inline">
+              <i class="fas fa-rocket"></i>
               <p>No deployments yet</p>
             </div>
             <% } %>
@@ -181,12 +181,12 @@
         <h2 class="card-title">Add Domain</h2>
       </div>
       <div class="card-body">
-        <form action="/webdev/microsites/<%= microsite.id %>/domains" method="POST" style="display: flex; gap: 12px; align-items: flex-end;">
-          <div class="form-group" style="flex: 1; margin-bottom: 0;">
+        <form action="/webdev/microsites/<%= microsite.id %>/domains" method="POST" class="domain-add-form">
+          <div class="form-group">
             <label class="form-label">Domain</label>
             <input type="text" name="domain" class="form-input" placeholder="subdomain.example.com" required>
           </div>
-          <div class="form-group" style="width: 160px; margin-bottom: 0;">
+          <div class="form-group" style="width: 160px;">
             <label class="form-label">Type</label>
             <select name="type" class="form-input">
               <option value="secondary">Secondary</option>
@@ -194,7 +194,7 @@
               <option value="staging">Staging</option>
             </select>
           </div>
-          <button type="submit" class="btn btn-primary" style="height: 42px;">
+          <button type="submit" class="btn btn-primary">
             <i class="fas fa-plus"></i> Add
           </button>
         </form>
@@ -207,35 +207,35 @@
       </div>
       <div class="card-body" style="padding: 0;">
         <% if (domains.length > 0) { %>
-        <table class="table">
+        <table class="table table-responsive-cards">
           <thead>
             <tr>
               <th>Domain</th>
               <th>Type</th>
               <th>DNS</th>
               <th>SSL</th>
-              <th style="text-align: right;">Actions</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
             <% domains.forEach(d => { %>
             <tr>
-              <td>
-                <a href="https://<%= d.domain %>" target="_blank" style="font-weight: 500;">
+              <td data-label="Domain">
+                <a href="https://<%= d.domain %>" target="_blank" style="font-weight: 500; word-break: break-all;">
                   <%= d.domain %> <i class="fas fa-external-link-alt" style="font-size: 10px;"></i>
                 </a>
               </td>
-              <td><span class="status-badge"><%= d.type %></span></td>
-              <td>
+              <td data-label="Type"><span class="status-badge"><%= d.type %></span></td>
+              <td data-label="DNS">
                 <span style="color: var(<%= d.dns_verified ? '--success' : '--warning' %>);">
                   <i class="fas fa-<%= d.dns_verified ? 'check-circle' : 'exclamation-triangle' %>"></i>
                   <%= d.dns_verified ? 'Verified' : 'Pending' %>
                 </span>
               </td>
-              <td>
+              <td data-label="SSL">
                 <span class="status-badge <%= d.ssl_status %>"><%= d.ssl_status %></span>
               </td>
-              <td style="text-align: right;">
+              <td data-label="Actions">
                 <form action="/webdev/microsites/<%= microsite.id %>/domains/<%= d.id %>/verify" method="POST" style="display: inline;">
                   <button type="submit" class="btn btn-sm btn-secondary" title="Toggle DNS verification">
                     <i class="fas fa-check"></i>
@@ -252,8 +252,8 @@
           </tbody>
         </table>
         <% } else { %>
-        <div style="padding: 40px; text-align: center; color: var(--gray-400);">
-          <i class="fas fa-globe" style="font-size: 32px; margin-bottom: 12px;"></i>
+        <div class="empty-state-inline">
+          <i class="fas fa-globe"></i>
           <p>No domains connected yet</p>
         </div>
         <% } %>
@@ -262,7 +262,7 @@
 
     <% } else if (tab === 'seo') { %>
     <!-- SEO TAB -->
-    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 24px;">
+    <div class="responsive-grid-2">
       <div>
         <div class="card">
           <div class="card-header">
@@ -368,12 +368,12 @@
     <!-- DEPLOYMENTS TAB -->
     <div class="card" style="margin-bottom: 20px;">
       <div class="card-body">
-        <form action="/webdev/microsites/<%= microsite.id %>/deploy" method="POST" style="display: flex; gap: 12px; align-items: flex-end;">
-          <div class="form-group" style="flex: 1; margin-bottom: 0;">
+        <form action="/webdev/microsites/<%= microsite.id %>/deploy" method="POST" class="deploy-form">
+          <div class="form-group">
             <label class="form-label">Deployment Note</label>
             <input type="text" name="commit_message" class="form-input" placeholder="What's being deployed?" value="">
           </div>
-          <button type="submit" class="btn btn-primary" style="height: 42px;">
+          <button type="submit" class="btn btn-primary">
             <i class="fas fa-rocket"></i> Log Deployment
           </button>
         </form>
@@ -386,7 +386,7 @@
       </div>
       <div class="card-body" style="padding: 0;">
         <% if (deployments.length > 0) { %>
-        <table class="table">
+        <table class="table table-responsive-cards">
           <thead>
             <tr>
               <th>Status</th>
@@ -399,23 +399,23 @@
           <tbody>
             <% deployments.forEach(d => { %>
             <tr>
-              <td>
+              <td data-label="Status">
                 <span class="status-badge <%= d.status %>">
                   <i class="fas fa-<%= d.status === 'success' ? 'check' : d.status === 'failed' ? 'times' : d.status === 'building' ? 'spinner fa-spin' : 'clock' %>"></i>
                   <%= d.status %>
                 </span>
               </td>
-              <td><%= d.commit_message || 'No message' %></td>
-              <td><span class="status-badge"><%= d.trigger %></span></td>
-              <td><%= d.first_name ? d.first_name + ' ' + (d.last_name || '') : 'System' %></td>
-              <td style="white-space: nowrap;"><%= new Date(d.created_at).toLocaleString() %></td>
+              <td data-label="Message"><%= d.commit_message || 'No message' %></td>
+              <td data-label="Trigger"><span class="status-badge"><%= d.trigger %></span></td>
+              <td data-label="Deployed By"><%= d.first_name ? d.first_name + ' ' + (d.last_name || '') : 'System' %></td>
+              <td data-label="Date"><%= new Date(d.created_at).toLocaleString() %></td>
             </tr>
             <% }); %>
           </tbody>
         </table>
         <% } else { %>
-        <div style="padding: 40px; text-align: center; color: var(--gray-400);">
-          <i class="fas fa-rocket" style="font-size: 32px; margin-bottom: 12px;"></i>
+        <div class="empty-state-inline">
+          <i class="fas fa-rocket"></i>
           <p>No deployment history</p>
         </div>
         <% } %>
@@ -424,7 +424,7 @@
 
     <% } else if (tab === 'settings') { %>
     <!-- SETTINGS TAB -->
-    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 24px;">
+    <div class="responsive-grid-2">
       <div class="card">
         <div class="card-header">
           <h2 class="card-title"><i class="fas fa-robot"></i> robots.txt</h2>
@@ -463,7 +463,7 @@ Sitemap: https://example.com/sitemap.xml"><%= microsite.robots_txt || '' %></tex
         </div>
 
         <div class="card" style="margin-top: 20px; border: 1px solid var(--danger);">
-          <div class="card-body" style="display: flex; justify-content: space-between; align-items: center;">
+          <div class="card-body delete-card-body">
             <div>
               <p style="font-weight: 600; color: var(--danger);">Delete Microsite</p>
               <p class="form-help">This will permanently remove the microsite and all associated data.</p>

--- a/wts-admin/src/views/webdev/submissions/list.ejs
+++ b/wts-admin/src/views/webdev/submissions/list.ejs
@@ -106,7 +106,7 @@
               <!-- Expandable detail row -->
               <tr class="detail-row" style="display: none;">
                 <td colspan="7" style="background: #f8fafc; padding: 1rem 1.5rem;">
-                  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; max-width: 800px;">
+                  <div class="responsive-grid-2" style="max-width: 800px;">
                     <% if (sub.phone) { %>
                     <div><strong>Phone:</strong> <%= sub.phone %></div>
                     <% } %>


### PR DESCRIPTION
- Add table-responsive-cards + data-label to 10 missed tables (automations, dashboard scheduled posts, calendar upcoming, analytics-dashboard campaigns/ top-posts, analytics content, retargeting audiences, microsites domains/ deployments, library list view)
- Replace hardcoded inline grid styles with responsive CSS classes (responsive-grid-2, responsive-grid-3, responsive-card-grid) across templates.ejs, retargeting.ejs, analytics-dashboard.ejs, microsites/detail, images/detail, submissions/list detail rows
- Add CSS: product preview panel 100% width on mobile, form-card max-width override, modal inline max-width override, seo-terms tooltip td fix, copy-toast centered on mobile, empty-state-inline, alert-banner, stat-bar, kv-row, quick-links-grid, legend-row, domain-add-form, deploy-form, delete-card-body, detail-row responsive classes
- Fix upload/upload-multiple: replace inline warning styles with alert-banner class, remove hardcoded max-width: 900px
- Fix iOS scroll lock: use position:fixed body lock pattern instead of overflow:hidden (prevents scroll-through on iOS Safari)

https://claude.ai/code/session_015ACtQqtE6zCM67S5qfRU3W