### PR TITLE
fix: eliminate all horizontal scrolling - vertical-only scrolling on …

### DIFF
--- a/wts-admin/public/css/style.css
+++ b/wts-admin/public/css/style.css
@@ -81,6 +81,7 @@ html {
   font-size: 16px;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
 }
 
 body {
@@ -89,6 +90,7 @@ body {
   color: var(--gray-800);
   line-height: 1.6;
   min-height: 100vh;
+  overflow-x: hidden;
 }
 
 a {
@@ -670,6 +672,8 @@ input, textarea, select {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
+  max-width: 100vw;
 }
 
 /* Header */
@@ -1153,7 +1157,8 @@ input, textarea, select {
 
 /* Tables */
 .table-container {
-  overflow-x: auto;
+  width: 100%;
+  overflow: hidden;
 }
 
 .table {
@@ -2449,12 +2454,10 @@ select.form-input {
   }
 
   .detail-tabs {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+    flex-wrap: wrap;
   }
 
   .detail-tab {
-    white-space: nowrap;
     padding: 10px 14px;
     font-size: 13px;
   }
@@ -3309,22 +3312,16 @@ select.form-input {
   }
 }
 
-/* Detail tabs horizontal scroll with no visible scrollbar */
+/* Detail tabs wrap on small mobile */
 @media (max-width: 640px) {
   .detail-tabs {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-  }
-
-  .detail-tabs::-webkit-scrollbar {
-    display: none;
+    flex-wrap: wrap;
+    gap: 4px;
   }
 
   .detail-tab {
-    white-space: nowrap;
-    flex-shrink: 0;
+    padding: 8px 12px;
+    font-size: 12px;
   }
 }
 
@@ -3881,9 +3878,13 @@ select.form-input {
     padding: 12px !important;
   }
 
-  pre[style*="overflow-x: auto"] {
+  pre[style*="overflow-x: auto"],
+  pre {
     font-size: 11px !important;
     padding: 8px !important;
+    white-space: pre-wrap !important;
+    word-break: break-word !important;
+    overflow-x: hidden !important;
   }
 }
 
@@ -3894,8 +3895,31 @@ select.form-input {
 @media (max-width: 768px) {
   .table:not(.table-responsive-cards) {
     display: block;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+    overflow: hidden;
+    width: 100%;
+  }
+
+  .table:not(.table-responsive-cards) thead {
+    display: none;
+  }
+
+  .table:not(.table-responsive-cards) tbody,
+  .table:not(.table-responsive-cards) tr {
+    display: block;
+    width: 100%;
+  }
+
+  .table:not(.table-responsive-cards) td {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--gray-100);
+  }
+
+  .table:not(.table-responsive-cards) tr {
+    border-bottom: 2px solid var(--gray-200);
+    padding: 8px 0;
   }
 }
 
@@ -4008,8 +4032,7 @@ select.form-input {
 
 @media (max-width: 768px) {
   .card-body[style*="padding: 0"] {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+    overflow: hidden;
   }
 }
 
@@ -4074,21 +4097,15 @@ select.form-input {
     width: 100%;
   }
 
-  /* Form tabs: horizontal scroll */
+  /* Form tabs: wrap into rows */
   .form-tabs {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+    flex-wrap: wrap;
     padding: 0 16px !important;
-    scrollbar-width: none;
-  }
-  .form-tabs::-webkit-scrollbar {
-    display: none;
+    gap: 0;
   }
   .form-tab {
-    white-space: nowrap;
     padding: 10px 14px;
     font-size: 13px;
-    flex-shrink: 0;
   }
 
   /* Form tab panels: less padding on mobile */
@@ -4101,18 +4118,13 @@ select.form-input {
     grid-template-columns: 1fr !important;
   }
 
-  /* Social tabs: scroll if needed */
+  /* Social tabs: wrap */
   .social-tabs {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-  }
-  .social-tabs::-webkit-scrollbar {
-    display: none;
+    flex-wrap: wrap;
   }
   .social-tab {
-    white-space: nowrap;
-    flex-shrink: 0;
+    flex: 1;
+    justify-content: center;
   }
 
   /* Social score checklist: single column */
@@ -4250,4 +4262,40 @@ select.form-input {
   .article-preview-frame {
     height: 300px !important;
   }
+}
+
+/* ==========================================
+   GLOBAL: PREVENT ALL HORIZONTAL SCROLL
+   Force grids with large minmax to single-column on small screens
+   ========================================== */
+@media (max-width: 480px) {
+  .ai-providers-grid {
+    grid-template-columns: 1fr !important;
+  }
+
+  .content-hub-grid {
+    grid-template-columns: 1fr !important;
+  }
+
+  /* Catch any grid with large minmax values */
+  [style*="minmax(3"],
+  [style*="minmax(4"],
+  [style*="minmax(5"] {
+    grid-template-columns: 1fr !important;
+  }
+}
+
+/* All pages: prevent any child from overflowing */
+.page-content {
+  overflow-x: hidden;
+}
+
+/* Ensure cards never exceed parent width */
+.card {
+  max-width: 100%;
+}
+
+/* All images and media: never exceed container */
+img, video, iframe, canvas, svg, embed, object {
+  max-width: 100%;
 }

--- a/wts-admin/src/views/content/articles/form.ejs
+++ b/wts-admin/src/views/content/articles/form.ejs
@@ -211,8 +211,8 @@
 
             <div class="form-group">
               <label class="form-label" for="time_to_read"><i class="fas fa-book-open"></i> Time to Read (minutes)</label>
-              <div style="display: flex; gap: 8px; align-items: center;">
-                <input type="number" id="time_to_read" name="time_to_read" class="form-input" min="1" placeholder="e.g. 5" value="<%= article && article.time_to_read ? article.time_to_read : '' %>" style="flex: 1;">
+              <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">
+                <input type="number" id="time_to_read" name="time_to_read" class="form-input" min="1" placeholder="e.g. 5" value="<%= article && article.time_to_read ? article.time_to_read : '' %>" style="flex: 1; min-width: 0;">
                 <button type="button" id="calcReadTimeBtn" class="btn btn-secondary btn-sm" title="Auto-calculate from content">
                   <i class="fas fa-calculator"></i> Calculate
                 </button>
@@ -541,7 +541,7 @@
             <div id="audioFieldsPanel" style="display: none;">
               <div id="audioLangRows"></div>
 
-              <div style="display: flex; gap: 8px; align-items: center; margin-top: 12px;">
+              <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-top: 12px;">
                 <select id="audioNewLangSelect" class="form-input" style="max-width: 180px; font-size: 13px;">
                   <option value="">Add language...</option>
                   <option value="en">English</option>
@@ -810,7 +810,7 @@
         <li>Category, Tags, Excerpt (if empty)</li>
       </ul>
       <p style="font-size: 13px; color: var(--gray-600); margin-bottom: 16px;"><strong>Note:</strong> Existing values in SEO, OG, and Twitter fields will be overwritten.</p>
-      <div style="display: flex; gap: 10px; justify-content: flex-end;">
+      <div style="display: flex; gap: 10px; justify-content: flex-end; flex-wrap: wrap;">
         <button type="button" class="btn btn-secondary" id="aiConfirmCancelBtn">Cancel</button>
         <button type="button" class="btn btn-primary" id="aiConfirmGoBtn">
           <i class="fas fa-robot"></i> Continue
@@ -829,7 +829,7 @@
     </div>
     <div class="modal-body">
       <p>You have unsaved changes that will be lost. Are you sure you want to leave?</p>
-      <div style="display: flex; gap: 10px; justify-content: flex-end; margin-top: 16px;">
+      <div style="display: flex; gap: 10px; justify-content: flex-end; flex-wrap: wrap; margin-top: 16px;">
         <button type="button" class="btn btn-secondary" id="unsavedStayBtn">Stay</button>
         <button type="button" class="btn btn-danger" id="unsavedLeaveBtn">Leave</button>
       </div>
@@ -1118,7 +1118,7 @@
 }
 .social-score-checklist {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(220px, 100%), 1fr));
   gap: 4px;
   font-size: 12px;
 }
@@ -1148,7 +1148,7 @@
 /* Preview Grid */
 .preview-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(340px, 100%), 1fr));
   gap: 20px;
 }
 .preview-card {
@@ -1644,7 +1644,7 @@
 /* ===== PUBLISH TAB STYLES ===== */
 .hyperlink-stats {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(160px, 100%), 1fr));
   gap: 8px;
   padding: 12px;
   background: var(--gray-50);
@@ -1730,7 +1730,7 @@
 }
 .image-modal-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(150px, 100%), 1fr));
   gap: 12px;
   max-height: 400px;
   overflow-y: auto;

--- a/wts-admin/src/views/social/ai-settings.ejs
+++ b/wts-admin/src/views/social/ai-settings.ejs
@@ -107,7 +107,7 @@
 <style>
 .ai-providers-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(320px, 100%), 1fr));
   gap: 20px;
 }
 .ai-provider-card.inactive {

--- a/wts-admin/src/views/social/content-hub.ejs
+++ b/wts-admin/src/views/social/content-hub.ejs
@@ -140,7 +140,7 @@
 }
 .content-hub-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(300px, 100%), 1fr));
   gap: 20px;
 }
 .content-hub-card {

--- a/wts-admin/src/views/social/posts/form.ejs
+++ b/wts-admin/src/views/social/posts/form.ejs
@@ -461,7 +461,7 @@
       <div style="margin-bottom: 16px;">
         <input type="text" id="imagePickerSearch" class="form-input" placeholder="Search images by title or filename...">
       </div>
-      <div id="imagePickerGrid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 10px;"></div>
+      <div id="imagePickerGrid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(140px, 100%), 1fr)); gap: 10px;"></div>
       <div id="imagePickerLoading" style="text-align: center; padding: 40px; color: var(--gray-400);">
         <i class="fas fa-spinner fa-spin"></i> Loading images...
       </div>


### PR DESCRIPTION
…mobile

- Add overflow-x: hidden on html, body, .main-content, .page-content to globally prevent any horizontal page scroll
- Replace all overflow-x: auto tab navigation (form-tabs, detail-tabs, social-tabs) with flex-wrap so tabs wrap into rows instead of scrolling
- Replace .table-container overflow-x: auto with overflow: hidden
- Convert non-responsive tables to block layout on mobile (hide thead, stack td cells vertically) instead of horizontal scroll
- Force pre/code blocks to white-space: pre-wrap on mobile instead of horizontal scroll
- Fix all CSS grid minmax values using min(Npx, 100%) pattern to prevent grid cells from exceeding container width on small screens
- Add flex-wrap: wrap to remaining inline flex containers (modal buttons, time-to-read row, audio language selector)
- Add global max-width: 100% on img, video, iframe, canvas, svg
- Add max-width: 100% on .card to prevent card overflow

https://claude.ai/code/session_015ACtQqtE6zCM67S5qfRU3W