### PR TITLE
feat: make admin header menu responsive with profile pushed right

### DIFF
--- a/wts-admin/public/css/style.css
+++ b/wts-admin/public/css/style.css
@@ -764,6 +764,9 @@ input, textarea, select {
   display: flex;
   align-items: center;
   gap: 12px;
+  margin-left: auto;
+  padding-right: 8px;
+  flex-shrink: 0;
 }
 
 .header-btn {
@@ -3085,7 +3088,7 @@ select.form-input {
   cursor: pointer;
 }
 
-@media (max-width: 480px) {
+@media (max-width: 768px) {
   .header-search {
     display: none;
   }
@@ -3094,8 +3097,24 @@ select.form-input {
     display: flex;
   }
 
+  .main-header {
+    padding: 0 12px;
+    gap: 8px;
+  }
+}
+
+@media (max-width: 480px) {
   .user-name-header {
     display: none;
+  }
+
+  .header-actions {
+    gap: 4px;
+    padding-right: 4px;
+  }
+
+  .user-dropdown-btn {
+    padding: 6px;
   }
 }
 


### PR DESCRIPTION
- Add margin-left: auto to .header-actions to push profile/notifications
  to the far right edge of the header
- Add padding-right buffer on the profile area
- Move search bar hiding from 480px to 768px breakpoint so tablets
  get the mobile search overlay instead of a cramped search bar
- Tighten header padding and gaps at 768px for better space usage
- Hide username and reduce spacing at 480px for small screens

https://claude.ai/code/session_01HhUrbmiLHCUF7c4eSGfcHp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved header layout alignment and spacing to enhance visual consistency across all screen sizes.
  * Refined responsive design breakpoints to ensure header controls and search functionality display optimally on both larger displays and compact devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->