### PR TITLE
wts-admin: PGSSL_VERIFY=verify-ca mode for proxy'd managed Postgres (deploy follow-up)

### DIFF
--- a/wts-admin/.env.example
+++ b/wts-admin/.env.example
@@ -25,6 +25,13 @@ DATABASE_URL=postgresql://user:password@localhost:5432/wts_admin
 # server CA certificate — either a file path or the PEM content itself.
 # (Railway: copy the CA from the Postgres service's variables/TLS info.)
 PGSSLROOTCERT=
+# Hostname verification mode (with PGSSLROOTCERT set):
+#   verify-full (default) — CA chain + hostname must match
+#   verify-ca             — CA chain only; use when the server cert's SANs
+#                           don't include the host you dial (e.g. Railway's
+#                           *.proxy.rlwy.net TCP proxy in front of a
+#                           self-signed Postgres certificate)
+# PGSSL_VERIFY=verify-full
 # Development-only escape hatch for managed DBs without the CA at hand
 # (accepts any certificate — never allowed in production):
 # PGSSL_INSECURE=true

--- a/wts-admin/database/db.js
+++ b/wts-admin/database/db.js
@@ -19,7 +19,24 @@ function getSslConfig() {
     const ca = rootCert.includes('-----BEGIN CERTIFICATE-----')
       ? rootCert
       : fs.readFileSync(rootCert, 'utf8');
-    return { ca, rejectUnauthorized: true };
+    // PGSSL_VERIFY:
+    //   verify-full (default) — validate the CA chain AND that the
+    //     certificate matches the host we dialed.
+    //   verify-ca — validate the chain against the CA but skip hostname
+    //     matching (Postgres sslmode=verify-ca semantics). Needed for
+    //     managed databases (e.g. Railway's TCP proxy) whose self-signed
+    //     certificates don't carry the proxy hostname in their SANs.
+    //     Never falls back automatically — downgrading is an explicit,
+    //     visible choice.
+    const mode = process.env.PGSSL_VERIFY || 'verify-full';
+    if (mode !== 'verify-full' && mode !== 'verify-ca') {
+      throw new Error(`Invalid PGSSL_VERIFY value "${mode}". Use "verify-full" (default) or "verify-ca".`);
+    }
+    const ssl = { ca, rejectUnauthorized: true };
+    if (mode === 'verify-ca') {
+      ssl.checkServerIdentity = () => undefined;
+    }
+    return ssl;
   }
 
   if (process.env.PGSSL_INSECURE === 'true') {

--- a/wts-admin/test/boot.test.js
+++ b/wts-admin/test/boot.test.js
@@ -18,6 +18,15 @@ test('production boot fails fast without database TLS configuration', async () =
   assert.match(output, /Database TLS is not configured/);
 });
 
+test('boot rejects an invalid PGSSL_VERIFY value', async () => {
+  const { code, output } = await runServerExpectingExit({
+    PGSSLROOTCERT: '-----BEGIN CERTIFICATE-----\nnot-validated-at-config-time\n-----END CERTIFICATE-----',
+    PGSSL_VERIFY: 'verify-nothing',
+  });
+  assert.notEqual(code, 0);
+  assert.match(output, /Invalid PGSSL_VERIFY value/);
+});
+
 test('telemetry endpoint fails closed when its secret is missing', async () => {
   const server = await startServer(3204, { TELEMETRY_WEBHOOK_SECRET: undefined });
   try {


### PR DESCRIPTION
Follow-up to #144, prompted by the failed production deployment `34d5a815`.

**What happened:** the deploy crash-looped on the new fail-fast TLS guard because `PGSSLROOTCERT` was never set in Railway (deploy-checklist step 2 of #144). That guard worked as designed — Railway kept the previous deployment active and production never went down. **The fix for the current failure is operational, not code:** set `PGSSLROOTCERT` on the `marketing` service (Railway's auto-diagnosis suggestion does exactly this).

**What this PR adds:** the next trip wire behind that one. Railway's TCP-proxy hostnames (`*.proxy.rlwy.net`) are typically not in the self-signed Postgres certificate's SANs, so once the CA is supplied, strict hostname verification can still fail — with no production-legal escape hatch. `PGSSL_VERIFY` now selects the verification mode when `PGSSLROOTCERT` is set:

- `verify-full` (default, unchanged): CA chain + hostname matching
- `verify-ca`: CA chain validation only (Postgres `sslmode=verify-ca` semantics) — still authenticates the server against the CA, only skips the SAN comparison. Never applied automatically.
- anything else refuses to boot (a typo must not silently change verification behavior)

Verified against a local TLS Postgres dialed via a deliberately mismatched DNS name: `verify-full` rejects with `Hostname/IP does not match certificate's altnames`, `verify-ca` connects with `pg_stat_ssl.ssl = true`. Suite green (27/27 with a new boot test for invalid values).

**Deploy sequence after merging:**
1. Set `PGSSLROOTCERT` on the service (CA PEM from the Postgres service).
2. Redeploy. If logs show `Hostname/IP does not match certificate's altnames`, set `PGSSL_VERIFY=verify-ca` and redeploy.
3. Once healthy: `railway run node scripts/promote-admin.js <admin-email>` — still pending from the #144 checklist; until then no account can use the admin UI.

https://claude.ai/code/session_01Bm8wt7tsZRoCLJiCf5JPqK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bm8wt7tsZRoCLJiCf5JPqK)_